### PR TITLE
feat: 프로필 아이디 컴포넌트 구현 (#17)

### DIFF
--- a/src/components/simple-profile/SimpleProfile.tsx
+++ b/src/components/simple-profile/SimpleProfile.tsx
@@ -1,6 +1,5 @@
-import { ROUTER_PATH } from '@/constants/constants';
 import { CgProfile } from 'react-icons/cg';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 type userData = {
   user_id: string;
@@ -9,9 +8,11 @@ type userData = {
 };
 
 const SimpleProfile = (userData: userData) => {
+  const navigate = useNavigate();
+
   return (
-    <Link
-      to={ROUTER_PATH.AUTHOR_DETAIL}
+    <div
+      onClick={() => navigate(`/author/${userData.user_id}`)}
       className="inline-block cursor-pointer"
     >
       <div className="flex items-center">
@@ -26,7 +27,7 @@ const SimpleProfile = (userData: userData) => {
           {userData.nickname || '데이터가 없습니다.'}
         </div>
       </div>
-    </Link>
+    </div>
   );
 };
 

--- a/src/components/simple-profile/SimpleProfile.tsx
+++ b/src/components/simple-profile/SimpleProfile.tsx
@@ -1,0 +1,33 @@
+import { ROUTER_PATH } from '@/constants/constants';
+import { CgProfile } from 'react-icons/cg';
+import { Link } from 'react-router-dom';
+
+type userData = {
+  user_id: string;
+  user_image: string;
+  nickname: string;
+};
+
+const SimpleProfile = (userData: userData) => {
+  return (
+    <Link
+      to={ROUTER_PATH.AUTHOR_DETAIL}
+      className="inline-block cursor-pointer"
+    >
+      <div className="flex items-center">
+        <div className="flex h-5 w-5 justify-center overflow-auto rounded-full border border-none">
+          {userData.user_image ? (
+            <img src={userData.user_image} alt="프로필사진" />
+          ) : (
+            <CgProfile size={20} />
+          )}
+        </div>
+        <div className="ml-1 text-xxsmall">
+          {userData.nickname || '데이터가 없습니다.'}
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default SimpleProfile;

--- a/src/components/simple-profile/SimpleProfile.tsx
+++ b/src/components/simple-profile/SimpleProfile.tsx
@@ -23,7 +23,7 @@ const SimpleProfile = (userData: userData) => {
             <CgProfile size={20} />
           )}
         </div>
-        <div className="ml-1 text-xxsmall">
+        <div className="ml-1 text-xxsmall font-semibold text-gray">
           {userData.nickname || '데이터가 없습니다.'}
         </div>
       </div>


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #17 

## ✅ Task Details

- 프로필 사진 + 아이디(댓글 작성자 및 영상 업로더) 공통컴포넌트 제작

## 📂 References

![image](https://github.com/user-attachments/assets/e620b41d-3310-4042-93da-fb8d842adaec)

After

![image](https://github.com/user-attachments/assets/562da7f1-3ee7-46c2-a107-f45463b7bb7d)


## 💞 Review Requirements

- 해당 컴포넌트에 userData를 내려주면 사용 가능합니다.
- 클릭시 해당 유저의 상세페이지로 이동하고자해서 Link 태그로 AUTHOR_DETAIL와 연결해두었습니다. 
- 이미지 데이터 없을 시 기본 이미지로 지정해놨고 이미지와 유저 닉네임으로 구성했습니다.
