### PR TITLE
feat: 영상 상세 페이지 댓글 파트에 댓글 추가 퍼블리싱 (#52)

### DIFF
--- a/src/components/comment/CommentActions.tsx
+++ b/src/components/comment/CommentActions.tsx
@@ -12,8 +12,9 @@ const CommentActions = ({
   hasReplies,
   comment_id,
   isExpanded,
+  isReply = false,
 }: CommentActionsProps) => {
-  const { toggleReplies } = useCommentStore();
+  const { toggleReplies, setInputFocus } = useCommentStore();
 
   return (
     <div className="flex items-center gap-4 text-sm text-gray">
@@ -25,6 +26,15 @@ const CommentActions = ({
         <IoMdThumbsDown size={14} />
         <span>{formatNumber(thumb_down)}</span>
       </button>
+
+      {!isReply && (
+        <button
+          onClick={() => setInputFocus(true)}
+          className="flex items-center gap-1 transition-colors duration-300 hover:text-primary"
+        >
+          댓글 달기
+        </button>
+      )}
 
       {hasReplies && (
         <button

--- a/src/components/comment/CommentInput.tsx
+++ b/src/components/comment/CommentInput.tsx
@@ -1,0 +1,35 @@
+import { useRef, useEffect } from 'react';
+
+import { IoMdSend } from 'react-icons/io';
+
+import { useCommentStore } from '@/store/useCommentStore';
+import Button from '../common/button/Button';
+
+const CommentInput = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isInputFocused = useCommentStore(state => state.isInputFocused);
+  const setInputFocus = useCommentStore(state => state.setInputFocus);
+
+  useEffect(() => {
+    if (isInputFocused && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.scrollIntoView({ behavior: 'smooth' });
+      setInputFocus(false);
+    }
+  }, [isInputFocused, setInputFocus]);
+
+  return (
+    <div className="mt-6 flex gap-2 border-t pt-4">
+      <input
+        ref={inputRef}
+        className="w-full rounded-lg border p-2 text-sm focus:border-primary focus:outline-none"
+        placeholder="댓글을 입력하세요..."
+      />
+      <Button variant="outline" size="small">
+        <IoMdSend size={20} />
+      </Button>
+    </div>
+  );
+};
+
+export default CommentInput;

--- a/src/components/comment/CommentItem.tsx
+++ b/src/components/comment/CommentItem.tsx
@@ -45,6 +45,7 @@ const CommentItem = ({ comment, isReply = false }: CommentItemProps) => {
           hasReplies={hasReplies}
           comment_id={comment.comment_id}
           isExpanded={isExpanded}
+          isReply={isReply}
         />
       </article>
     </section>

--- a/src/components/comment/VideoComment.tsx
+++ b/src/components/comment/VideoComment.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import CommentList from './CommentList';
+import CommentInput from './CommentInput';
 import EmptyResult from '../empty/EmptyResult';
 import { useCommentStore } from '@/store/useCommentStore';
 import { formatNumber } from '@/utils/formatNumber';
@@ -16,7 +17,11 @@ const VideoComment = ({ videoId }: VideoCommentProps) => {
     fetchCommentsByVideoId(videoId);
 
     return () => {
-      useCommentStore.setState({ comments: [], expandedComments: [] });
+      useCommentStore.setState({
+        comments: [],
+        expandedComments: [],
+        isInputFocused: false,
+      });
     };
   }, [videoId, fetchCommentsByVideoId]);
 
@@ -32,6 +37,7 @@ const VideoComment = ({ videoId }: VideoCommentProps) => {
       ) : (
         <EmptyResult message="작성된 댓글이 없습니다." />
       )}
+      <CommentInput />
     </main>
   );
 };

--- a/src/store/useCommentStore.ts
+++ b/src/store/useCommentStore.ts
@@ -6,6 +6,7 @@ import { mockComments } from '@/mocks/mockComment';
 const useCommentStore = create<CommentStore>(set => ({
   comments: [],
   expandedComments: [],
+  isInputFocused: false,
   fetchCommentsByVideoId: (video_id: string) => {
     const comments = mockComments.filter(
       comment => comment.video_id === video_id,
@@ -18,6 +19,9 @@ const useCommentStore = create<CommentStore>(set => ({
         ? state.expandedComments.filter(id => id !== comment_id)
         : [...state.expandedComments, comment_id],
     }));
+  },
+  setInputFocus: (isFocused: boolean) => {
+    set({ isInputFocused: isFocused });
   },
 }));
 

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -36,6 +36,7 @@ type CommentActionsProps = {
   hasReplies?: boolean;
   comment_id: string;
   isExpanded: boolean;
+  isReply?: boolean;
 };
 
 type CommentItemProps = {
@@ -46,8 +47,10 @@ type CommentItemProps = {
 interface CommentStore {
   comments: Comment[];
   expandedComments: string[];
+  isInputFocused: boolean;
   fetchCommentsByVideoId: (video_id: string) => void;
   toggleReplies: (comment_id: string) => void;
+  setInputFocus: (isFocused: boolean) => void;
 }
 
 export type {


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #52 

## ✅ Task Details

- 대댓글이 아닌 경우에만 댓글 달기 버튼을 추가했어요.
- 댓글 컴포넌트를 추가하고 '댓글 달기'를 누르면 포커싱되어 스크롤링되도록 스토어에서 관리했어요. 

## 📂 References

https://github.com/user-attachments/assets/c21c9f52-1e0f-4f26-ae82-fa0c748fc7ac

## 💞 Review Requirements

- 리뷰 요구사항을 적어주세요!
