### PR TITLE
feat: supabase에서 영상 데이터 가져오기 (#66)

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,9 +1,21 @@
 import { supabase } from './Supabase';
 import { UserProps, UpdateData } from '@/types/user';
 
-// 사용자 조회
+// 모든 사용자 조회
 export async function fetchUsers() {
   const { data, error } = await supabase.from('users').select('*');
+
+  if (error) throw error;
+  return data;
+}
+
+// 단일 사용자 조회
+export async function fetchUserById(userId: string) {
+  const { data, error } = await supabase
+    .from('users')
+    .select('*')
+    .eq('user_id', userId)
+    .single();
 
   if (error) throw error;
   return data;

--- a/src/api/videos.ts
+++ b/src/api/videos.ts
@@ -1,0 +1,21 @@
+import { supabase } from './Supabase';
+
+// 모든 영상 조회
+export async function fetchVideos() {
+  const { data, error } = await supabase.from('videos').select('*');
+
+  if (error) throw error;
+  return data;
+}
+
+// 단일 영상 조회
+export async function fetchVideo(videoId: string) {
+  const { data, error } = await supabase
+    .from('videos')
+    .select('*')
+    .eq('video_id', videoId)
+    .single();
+
+  if (error) throw error;
+  return data;
+}

--- a/src/components/skeleton/author/AuthorProfileSkeleton.tsx
+++ b/src/components/skeleton/author/AuthorProfileSkeleton.tsx
@@ -1,0 +1,29 @@
+const AuthorProfileSkeleton = () => {
+  return (
+    <section className="flex animate-pulse flex-col gap-3">
+      <header className="flex items-center gap-4">
+        <div className="h-7 w-40 rounded-md bg-gray-200" />
+        <div className="h-7 w-16 rounded-md bg-gray-200" />
+      </header>
+
+      <article className="flex items-center gap-6 px-2">
+        <div className="h-16 w-16 rounded-full bg-gray-200" />
+
+        <dl className="flex items-center gap-8">
+          {[...Array(3)].map((_, index) => (
+            <div key={index} className="text-center">
+              <div className="mb-1 h-4 w-12 rounded bg-gray-200" />
+              <div className="h-6 w-12 rounded bg-gray-200" />
+            </div>
+          ))}
+        </dl>
+      </article>
+
+      <div className="px-2">
+        <div className="h-4 w-3/4 rounded bg-gray-200" />
+      </div>
+    </section>
+  );
+};
+
+export default AuthorProfileSkeleton;

--- a/src/components/skeleton/video/VideoItemSkeleton.tsx
+++ b/src/components/skeleton/video/VideoItemSkeleton.tsx
@@ -1,0 +1,33 @@
+const VideoItemSkeleton = () => {
+  return (
+    <article className="mb-1 w-full animate-pulse">
+      <div className="relative mb-2 aspect-video w-full overflow-hidden rounded-lg bg-gray-200" />
+
+      <div className="px-1">
+        <div className="mb-2 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 rounded-full bg-gray-200" />
+            <div className="h-5 w-24 rounded bg-gray-200" />
+          </div>
+
+          <div className="flex gap-2">
+            <div className="h-5 w-14 rounded bg-gray-200" />
+            <div className="h-5 w-14 rounded bg-gray-200" />
+            <div className="h-5 w-14 rounded bg-gray-200" />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="h-5 w-3/4 rounded bg-gray-200" />
+          <div className="flex gap-2">
+            <div className="h-4 w-12 rounded bg-gray-200" />
+            <div className="h-4 w-12 rounded bg-gray-200" />
+            <div className="h-4 w-12 rounded bg-gray-200" />
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default VideoItemSkeleton;

--- a/src/components/skeleton/video/VideoListSkeleton.tsx
+++ b/src/components/skeleton/video/VideoListSkeleton.tsx
@@ -1,0 +1,15 @@
+import VideoItemSkeleton from './VideoItemSkeleton';
+
+const VideoListSkeleton = () => {
+  const emptyArray = Array.from({ length: 5 }, (_, index) => index + 1);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {emptyArray.map(item => (
+        <VideoItemSkeleton key={item} />
+      ))}
+    </div>
+  );
+};
+
+export default VideoListSkeleton;

--- a/src/hooks/useUsers.tsx
+++ b/src/hooks/useUsers.tsx
@@ -1,14 +1,27 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { addUser, deleteUser, fetchUsers, updateUser } from '@/api/users';
+import {
+  addUser,
+  deleteUser,
+  fetchUsers,
+  fetchUserById,
+  updateUser,
+} from '@/api/users';
 
 import { UserProps, UpdateData } from '@/types/user';
 
-const useUsers = () => {
-  // 사용자 조회
+const useUsers = (userId?: string) => {
+  // 모든 사용자 조회
   const usersQuery = useQuery({
     queryKey: ['users'],
     queryFn: fetchUsers,
+  });
+
+  // 단일 사용자 조회
+  const userQuery = useQuery({
+    queryKey: ['user', userId],
+    queryFn: () => fetchUserById(userId!),
+    enabled: !!userId,
   });
 
   // 사용자 추가
@@ -34,6 +47,7 @@ const useUsers = () => {
 
   return {
     usersQuery,
+    userQuery,
     addUserMutation,
     deleteUserMutation,
     updateUserMutation,

--- a/src/hooks/useVideos.tsx
+++ b/src/hooks/useVideos.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchVideos, fetchVideo } from '@/api/videos';
+
+const useVideos = (videoId?: string) => {
+  const videosQuery = useQuery({
+    queryKey: ['videos'],
+    queryFn: fetchVideos,
+    select: data => {
+      return data.map(video => ({
+        ...video,
+        created_at: new Date(video.created_at),
+      }));
+    },
+  });
+
+  const videoQuery = useQuery({
+    queryKey: ['video', videoId],
+    queryFn: () => fetchVideo(videoId!),
+    select: data => ({
+      ...data,
+      created_at: new Date(data.created_at),
+    }),
+    enabled: !!videoId,
+  });
+
+  return {
+    videosQuery,
+    videoQuery,
+  };
+};
+
+export { useVideos };

--- a/src/pages/AuthorDetailPage.tsx
+++ b/src/pages/AuthorDetailPage.tsx
@@ -6,29 +6,45 @@ import VideoList from '@/components/video/VideoList';
 import VideoSortNav from '@/components/video/VideoSortNav';
 import AuthorProfile from '@/components/author/AuthorProfile';
 import EmptyResult from '@/components/empty/EmptyResult';
-import { mockUsers } from '@/mocks/mockUsers';
-import { mockVideos } from '@/mocks/mockVideos';
-import NotFoundPage from './NotFoundPage';
+import AuthorProfileSkeleton from '@/components/skeleton/author/AuthorProfileSkeleton';
+import VideoListSkeleton from '@/components/skeleton/video/VideoListSkeleton';
+import { useVideos } from '@/hooks/useVideos';
+import { useUsers } from '@/hooks/useUsers';
 
 const AuthorDetailPage = () => {
   const [sortType, setSortType] = useState<'latest' | 'popular'>('latest');
   const { userId } = useParams<{ userId: string }>();
+  const { userQuery } = useUsers(userId);
+  const { videosQuery } = useVideos();
 
-  const author = mockUsers.find(user => user.user_id === userId);
-  const authorVideos = mockVideos
-    .filter(video => video.user_id === userId)
-    .sort((a, b) => {
-      if (sortType === 'latest') {
-        return (
-          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-        );
-      }
-      return b.like_heart - a.like_heart;
-    });
+  const { data: author, isLoading: isAuthorLoading } = userQuery;
+  const { data: videos, isLoading: isVideosLoading } = videosQuery;
 
-  if (!author) {
-    return <NotFoundPage />;
+  if (isAuthorLoading || isVideosLoading) {
+    return (
+      <main className="flex flex-col">
+        <AuthorProfileSkeleton />
+        <hr className="my-3" aria-hidden="true" />
+        <header className="mb-2 flex items-center justify-between">
+          <h2 className="font-bold">작성자가 업로드한 영상</h2>
+          <VideoSortNav sortType={sortType} onSortChange={setSortType} />
+        </header>
+        <VideoListSkeleton />
+      </main>
+    );
   }
+
+  const authorVideos =
+    videos
+      ?.filter(video => video.user_id === userId)
+      .sort((a, b) => {
+        if (sortType === 'latest') {
+          return (
+            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+          );
+        }
+        return b.like_heart - a.like_heart;
+      }) ?? [];
 
   return (
     <main className="flex flex-col">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,12 +3,30 @@ import { useState } from 'react';
 import VideoCategory from '@/components/video/VideoCategory';
 import VideoList from '@/components/video/VideoList';
 import EmptyResult from '@/components/empty/EmptyResult';
-import { mockVideos } from '@/mocks/mockVideos';
+import VideoListSkeleton from '@/components/skeleton/video/VideoListSkeleton';
+import { useVideos } from '@/hooks/useVideos';
 
 const HomePage = () => {
   const [selectedCategory, setSelectedCategory] = useState('전체');
+  const { videosQuery } = useVideos();
 
-  const filteredVideos = mockVideos.filter(video => {
+  const { data: videos, isLoading } = videosQuery;
+
+  if (isLoading) {
+    return (
+      <main className="flex flex-col gap-2">
+        <VideoCategory
+          selectedCategory={selectedCategory}
+          onCategoryChange={setSelectedCategory}
+        />
+        <VideoListSkeleton />
+      </main>
+    );
+  }
+
+  if (!videos) return <EmptyResult message="영상이 아무것도 없어요!" />;
+
+  const filteredVideos = videos.filter(video => {
     if (selectedCategory === '전체') return true;
     return video.hash_tag.includes(selectedCategory);
   });

--- a/src/pages/VideoDetailPage.tsx
+++ b/src/pages/VideoDetailPage.tsx
@@ -3,23 +3,22 @@ import { useParams } from 'react-router-dom';
 import NotFoundPage from './NotFoundPage';
 import VideoItem from '@/components/video/VideoItem';
 import VideoComment from '@/components/comment/VideoComment';
-import { mockVideos } from '@/mocks/mockVideos';
-import { VideoProps } from '@/types/video';
+import VideoItemSkeleton from '@/components/skeleton/video/VideoItemSkeleton';
+import { useVideos } from '@/hooks/useVideos';
 
 const VideoDetailPage = () => {
   const { videoId } = useParams<{ videoId: string }>();
+  const { videoQuery } = useVideos(videoId);
 
-  const videoData = mockVideos.find(
-    video => video.video_id === videoId,
-  ) as VideoProps;
+  const { data: video, isLoading, isError } = videoQuery;
 
-  if (!videoId || !videoData) {
-    return <NotFoundPage />;
-  }
+  if (!videoId) return <NotFoundPage />;
+  if (isLoading) return <VideoItemSkeleton />;
+  if (isError || !video) return <NotFoundPage />;
 
   return (
     <>
-      <VideoItem {...videoData} isVideoDetailPage />
+      <VideoItem {...video} isVideoDetailPage />
       <VideoComment videoId={videoId} />
     </>
   );

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -9,7 +9,7 @@ type VideoProps = {
   hash_tag: string[];
   like_heart: number;
   is_bookmarked: boolean;
-  created_at: string;
+  created_at: string | Date;
   isVideoDetailPage?: boolean;
 };
 

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -9,7 +9,7 @@ type VideoProps = {
   hash_tag: string[];
   like_heart: number;
   is_bookmarked: boolean;
-  created_at: Date;
+  created_at: string;
   isVideoDetailPage?: boolean;
 };
 

--- a/src/utils/getTimeAgo.ts
+++ b/src/utils/getTimeAgo.ts
@@ -1,8 +1,9 @@
-const getTimeAgo = (date: Date) => {
+const getTimeAgo = (date: Date | string) => {
+  const dateObject = date instanceof Date ? date : new Date(date);
   const now = new Date();
 
   const diffInHours = Math.floor(
-    (now.getTime() - date.getTime()) / (1000 * 60 * 60),
+    (now.getTime() - dateObject.getTime()) / (1000 * 60 * 60),
   );
   if (diffInHours < 24) {
     return `${diffInHours}시간 전`;


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #66 

## ✅ Task Details

- supabase에서 `created_at`이 문자열 형태로 와서 `string`이나 `Date`로 설정했어요. `string`으로만 설정하려 했는데 일단 다른 곳에서 에러가 보여 `Date`도 같이 포함시켰어요.
- 영상 리스트, 단일 영상, 작성자 상세 페이지에 스켈레톤을 추가했어요. → 로딩 시에 스켈레톤이 보여져요.
- 메인페이지, 작성자 페이지, 영상 상세 페이지 쪽에서 단일 사용자 조회, 모든 영상 조회, 단일 영상 조회 훅을 만들었어요. 

## 📂 References

https://github.com/user-attachments/assets/51d14744-b6df-4c8a-85db-1a17461959a6

## 💞 Review Requirements

- 사용자 api → `api/users.ts`
- 영상 api → `api/videos.ts`
- 사용자 훅 → `hooks/useUsers.ts`
- 영상 훅 → `hooks/useVideos.ts`
