### PR TITLE
feat: 영상 상세 페이지에서 댓글 추가, 조회 구현 (#72)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "react": "^18.3.1",
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.54.2",
+        "react-hot-toast": "^2.5.1",
         "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.1",
         "swiper": "^11.2.0",
@@ -2950,6 +2952,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -4149,6 +4160,39 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.1.tgz",
+      "integrity": "sha512-54Gq1ZD1JbmAb4psp9bvFHjS7lje+8ubboUmvKZkCsQBLH6AOpZ9JemfRvIdHcfb9AZXRaFLrb3qUobGYDJhFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "react": "^18.3.1",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.54.2",
+    "react-hot-toast": "^2.5.1",
     "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.1",
     "swiper": "^11.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,14 @@
+import { Toaster } from 'react-hot-toast';
+
 import Router from './routes/Router';
 
 const App = () => {
-  return <Router />;
+  return (
+    <>
+      <Toaster />
+      <Router />
+    </>
+  );
 };
 
 export default App;

--- a/src/api/comments.ts
+++ b/src/api/comments.ts
@@ -1,0 +1,111 @@
+import { supabase } from './Supabase';
+
+import { Comment, Reply } from '@/types/comment';
+
+type RawComment = Omit<Comment, 'replies'>;
+
+// 모든 댓글과 대댓글 조회
+export async function fetchCommentsByVideoId(
+  videoId: string,
+): Promise<Comment[]> {
+  try {
+    // 댓글 조회
+    const { data: comments, error: commentsError } = await supabase
+      .from('comments')
+      .select('*')
+      .eq('video_id', videoId)
+      .order('created_at', { ascending: false });
+
+    if (commentsError) throw commentsError;
+    if (!comments) return [];
+
+    const rawComments = comments as RawComment[];
+
+    // 대댓글 조회
+    const { data: replies, error: repliesError } = await supabase
+      .from('replies')
+      .select('*')
+      .in(
+        'comment_id',
+        rawComments.map(comment => comment.comment_id),
+      )
+      .order('created_at', { ascending: false });
+
+    if (repliesError) throw repliesError;
+
+    const commentsWithReplies: Comment[] = rawComments.map(comment => ({
+      ...comment,
+      replies: (replies || []).filter(
+        reply => reply.comment_id === comment.comment_id,
+      ) as Reply[],
+    }));
+
+    return commentsWithReplies;
+  } catch (error) {
+    console.error('영상에 대한 댓글을 가져오는 데에 오류가 발생했어요!', error);
+    throw error;
+  }
+}
+
+// 댓글 추가
+export async function addComment(
+  videoId: string,
+  content: string,
+  userId: string, // 사용자 정보가 없어서 임시로 추가
+  nickname: string, // 사용자 정보가 없어서 임시로 추가
+): Promise<Comment> {
+  const newComment = {
+    comment_id: crypto.randomUUID(),
+    video_id: videoId,
+    user_id: userId,
+    nickname,
+    comment: content,
+    created_at: new Date(),
+    thumb_up: 0,
+    thumb_down: 0,
+  };
+
+  const { data, error } = await supabase
+    .from('comments')
+    .insert([newComment])
+    .select('*')
+    .single();
+
+  if (error) throw error;
+  if (!data) throw new Error('댓글을 추가하는 데에 실패했어요!');
+
+  return {
+    ...data,
+    replies: [],
+  } as Comment;
+}
+
+// 대댓글 추가
+export async function addReply(
+  commentId: string,
+  content: string,
+  userId: string, // 사용자 정보가 없어서 임시로 추가
+  nickname: string, // 사용자 정보가 없어서 임시로 추가
+): Promise<Reply> {
+  const newReply = {
+    reply_id: crypto.randomUUID(),
+    comment_id: commentId,
+    user_id: userId,
+    nickname,
+    reply_comment: content,
+    created_at: new Date(),
+    thumb_up: 0,
+    thumb_down: 0,
+  };
+
+  const { data, error } = await supabase
+    .from('replies')
+    .insert([newReply])
+    .select('*')
+    .single();
+
+  if (error) throw error;
+  if (!data) throw new Error('대댓글을 추가하는 데에 실패했어요!');
+
+  return data as Reply;
+}

--- a/src/components/comment/CommentActions.tsx
+++ b/src/components/comment/CommentActions.tsx
@@ -14,7 +14,13 @@ const CommentActions = ({
   isExpanded,
   isReply = false,
 }: CommentActionsProps) => {
-  const { toggleReplies, setInputFocus } = useCommentStore();
+  const { toggleReplies, setInputFocus, setActiveCommentId } =
+    useCommentStore();
+
+  const handleReplyClick = () => {
+    setActiveCommentId(comment_id);
+    setInputFocus(true);
+  };
 
   return (
     <div className="flex items-center gap-4 text-sm text-gray">
@@ -29,7 +35,7 @@ const CommentActions = ({
 
       {!isReply && (
         <button
-          onClick={() => setInputFocus(true)}
+          onClick={handleReplyClick}
           className="flex items-center gap-1 transition-colors duration-300 hover:text-primary"
         >
           댓글 달기

--- a/src/components/comment/CommentList.tsx
+++ b/src/components/comment/CommentList.tsx
@@ -1,9 +1,14 @@
 import CommentItem from './CommentItem';
 import { useCommentStore } from '@/store/useCommentStore';
+import { Comment } from '@/types/comment';
 import { cn } from '@/utils/cn';
 
-const CommentList = () => {
-  const { comments, expandedComments } = useCommentStore();
+type CommentListProps = {
+  comments: Comment[];
+};
+
+const CommentList = ({ comments }: CommentListProps) => {
+  const { expandedComments } = useCommentStore();
 
   return (
     <ul className="space-y-6">

--- a/src/components/comment/CommentSubmitForm.tsx
+++ b/src/components/comment/CommentSubmitForm.tsx
@@ -1,0 +1,104 @@
+import { useForm } from 'react-hook-form';
+import { IoMdSend } from 'react-icons/io';
+
+import Button from '../common/button/Button';
+import { toastSuccess, toastError } from '@/utils/toast';
+import { CommentSubmitFormProps } from '@/types/comment';
+
+interface CommentFormData {
+  content: string;
+}
+
+const CommentSubmitForm = ({
+  isSubmitting,
+  isReplyMode,
+  onSubmit,
+  onCancel,
+}: CommentSubmitFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<CommentFormData>({
+    defaultValues: {
+      content: '',
+    },
+    mode: 'onChange',
+  });
+
+  const content = watch('content');
+  const isSubmitDisabled = !content?.trim() || isSubmitting;
+
+  const handleCancel = () => {
+    reset({ content: '' });
+    onCancel?.();
+  };
+
+  const handleFormSubmit = async (data: CommentFormData) => {
+    try {
+      await onSubmit(data.content);
+      reset({ content: '' });
+      toastSuccess(
+        isReplyMode ? '대댓글이 추가되었어요!' : '댓글이 추가되었어요!',
+      );
+    } catch (error) {
+      console.error('댓글 작성에 실패했어요!', error);
+      toastError('댓글 작성에 실패했어요!');
+    }
+  };
+
+  return (
+    <div className="mt-2">
+      <form
+        onSubmit={handleSubmit(handleFormSubmit)}
+        className="mt-6 flex gap-2 border-t pt-4"
+      >
+        <input
+          {...register('content', {
+            required: '내용을 입력해주세요!',
+            maxLength: {
+              value: 500,
+              message: '댓글은 최대 500자까지 입력할 수 있어요!',
+            },
+          })}
+          className="w-full rounded-lg border p-2 text-sm focus:border-primary focus:outline-none"
+          placeholder={
+            isReplyMode ? '대댓글을 입력하세요...' : '댓글을 입력하세요...'
+          }
+        />
+
+        <div className="flex gap-2">
+          {isReplyMode && (
+            <Button
+              type="button"
+              variant="danger"
+              size="small"
+              onClick={handleCancel}
+              disabled={isSubmitting}
+              className="break-keep"
+            >
+              취소
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            size="small"
+            type="submit"
+            disabled={isSubmitDisabled || content?.length > 500}
+          >
+            <IoMdSend size={20} />
+          </Button>
+        </div>
+      </form>
+      {errors.content && (
+        <span className="mx-2 text-xs text-red-500">
+          {errors.content.message}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default CommentSubmitForm;

--- a/src/components/comment/VideoComment.tsx
+++ b/src/components/comment/VideoComment.tsx
@@ -5,25 +5,24 @@ import CommentInput from './CommentInput';
 import EmptyResult from '../empty/EmptyResult';
 import { useCommentStore } from '@/store/useCommentStore';
 import { formatNumber } from '@/utils/formatNumber';
+import { useComments } from '@/hooks/useComments';
 
 type VideoCommentProps = {
   videoId: string;
 };
 
 const VideoComment = ({ videoId }: VideoCommentProps) => {
-  const { comments, fetchCommentsByVideoId } = useCommentStore();
+  const { comments, isLoading } = useComments(videoId);
+  const resetExpandedComments = useCommentStore(
+    state => state.resetExapandedComments,
+  );
 
+  // 펼쳐진 댓글 초기화를 위함
   useEffect(() => {
-    fetchCommentsByVideoId(videoId);
+    resetExpandedComments();
+  }, [videoId, resetExpandedComments]);
 
-    return () => {
-      useCommentStore.setState({
-        comments: [],
-        expandedComments: [],
-        isInputFocused: false,
-      });
-    };
-  }, [videoId, fetchCommentsByVideoId]);
+  if (isLoading) return <div>로딩중...</div>;
 
   return (
     <main className="mt-6">
@@ -33,11 +32,11 @@ const VideoComment = ({ videoId }: VideoCommentProps) => {
       <hr className="my-1" aria-hidden="true" />
 
       {comments.length > 0 ? (
-        <CommentList />
+        <CommentList comments={comments} />
       ) : (
         <EmptyResult message="작성된 댓글이 없습니다." />
       )}
-      <CommentInput />
+      <CommentInput videoId={videoId} />
     </main>
   );
 };

--- a/src/components/video/VideoStats.tsx
+++ b/src/components/video/VideoStats.tsx
@@ -3,10 +3,10 @@ import { IoHeartOutline } from 'react-icons/io5';
 import { VscComment } from 'react-icons/vsc';
 import { FaStar, FaRegStar } from 'react-icons/fa';
 
+import { useComments } from '@/hooks/useComments';
 import { formatNumber } from '@/utils/formatNumber';
 import { getTimeAgo } from '@/utils/getTimeAgo';
 import { VideoStatsProps } from '@/types/video';
-import { mockComments } from '@/mocks/mockComment';
 
 const VideoStats = ({
   video_id,
@@ -14,9 +14,7 @@ const VideoStats = ({
   is_bookmarked,
   like_heart,
 }: VideoStatsProps) => {
-  const commentsCount = mockComments.filter(
-    comment => comment.video_id === video_id,
-  ).length;
+  const { comments } = useComments(video_id);
 
   return (
     <div className="flex items-center gap-2 text-gray">
@@ -32,7 +30,7 @@ const VideoStats = ({
 
       <div className="flex items-center">
         <VscComment size={16} className="mr-1" />
-        <span className="text-xs">{formatNumber(commentsCount)}</span>
+        <span className="text-xs">{formatNumber(comments.length)}</span>
       </div>
 
       <div className="flex items-center">

--- a/src/hooks/useComments.tsx
+++ b/src/hooks/useComments.tsx
@@ -1,0 +1,72 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { fetchCommentsByVideoId, addComment, addReply } from '@/api/comments';
+import { Comment } from '@/types/comment';
+
+const useComments = (videoId: string) => {
+  const queryClient = useQueryClient();
+
+  // 모든 댓글 조회
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['comments', videoId],
+    queryFn: () => fetchCommentsByVideoId(videoId),
+  });
+
+  // 댓글 추가
+  const { mutateAsync: addCommentAsync, isPending: isAddingComment } =
+    useMutation({
+      mutationFn: ({
+        content,
+        userId,
+        nickname,
+      }: {
+        content: string;
+        userId: string;
+        nickname: string;
+      }) => addComment(videoId, content, userId, nickname),
+      onSuccess: newComment => {
+        queryClient.setQueryData<Comment[]>(
+          ['comments', videoId],
+          (oldComments = []) => [...oldComments, newComment],
+        );
+      },
+    });
+
+  // 대댓글 추가
+  const { mutateAsync: addReplyAsync, isPending: isAddingReply } = useMutation({
+    mutationFn: ({
+      commentId,
+      content,
+      userId,
+      nickname,
+    }: {
+      commentId: string;
+      content: string;
+      userId: string;
+      nickname: string;
+    }) => addReply(commentId, content, userId, nickname),
+    onSuccess: (newReply, { commentId }) => {
+      queryClient.setQueryData<Comment[]>(
+        ['comments', videoId],
+        (oldComments = []) =>
+          oldComments.map(comment =>
+            comment.comment_id === commentId
+              ? { ...comment, replies: [...comment.replies, newReply] }
+              : comment,
+          ),
+      );
+    },
+  });
+
+  return {
+    comments: data ?? [],
+    isLoading,
+    error,
+    addComment: addCommentAsync,
+    isAddingComment,
+    addReply: addReplyAsync,
+    isAddingReply,
+  };
+};
+
+export { useComments };

--- a/src/store/useCommentStore.ts
+++ b/src/store/useCommentStore.ts
@@ -1,18 +1,11 @@
 import { create } from 'zustand';
 
 import { CommentStore } from '@/types/comment';
-import { mockComments } from '@/mocks/mockComment';
 
 const useCommentStore = create<CommentStore>(set => ({
-  comments: [],
   expandedComments: [],
   isInputFocused: false,
-  fetchCommentsByVideoId: (video_id: string) => {
-    const comments = mockComments.filter(
-      comment => comment.video_id === video_id,
-    );
-    set({ comments, expandedComments: [] });
-  },
+  activeCommentId: null,
   toggleReplies: (comment_id: string) => {
     set(state => ({
       expandedComments: state.expandedComments.includes(comment_id)
@@ -23,6 +16,10 @@ const useCommentStore = create<CommentStore>(set => ({
   setInputFocus: (isFocused: boolean) => {
     set({ isInputFocused: isFocused });
   },
+  resetExapandedComments: () => {
+    set({ expandedComments: [] });
+  },
+  setActiveCommentId: comment_id => set({ activeCommentId: comment_id }),
 }));
 
 export { useCommentStore };

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -45,12 +45,13 @@ type CommentItemProps = {
 };
 
 interface CommentStore {
-  comments: Comment[];
   expandedComments: string[];
   isInputFocused: boolean;
-  fetchCommentsByVideoId: (video_id: string) => void;
+  activeCommentId: string | null;
   toggleReplies: (comment_id: string) => void;
   setInputFocus: (isFocused: boolean) => void;
+  resetExapandedComments: () => void;
+  setActiveCommentId: (comment_id: string | null) => void;
 }
 
 export type {

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -44,6 +44,13 @@ type CommentItemProps = {
   isReply?: boolean;
 };
 
+type CommentSubmitFormProps = {
+  isReplyMode?: boolean;
+  isSubmitting: boolean;
+  onSubmit: (content: string) => Promise<void>;
+  onCancel?: () => void;
+};
+
 interface CommentStore {
   expandedComments: string[];
   isInputFocused: boolean;
@@ -60,5 +67,6 @@ export type {
   CombinedCommentProps,
   CommentActionsProps,
   CommentItemProps,
+  CommentSubmitFormProps,
   CommentStore,
 };

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,21 @@
+import toast from 'react-hot-toast';
+
+const toastSuccess = (message: string) => {
+  toast.success(message, {
+    duration: 1500,
+    style: {
+      fontSize: 'var(--font-small)',
+    },
+  });
+};
+
+const toastError = (message: string) => {
+  toast.error(message, {
+    duration: 1500,
+    style: {
+      fontSize: 'var(--font-small)',
+    },
+  });
+};
+
+export { toastSuccess, toastError };


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #72 

## ✅ Task Details

- `react-hook-form`, `react-hot-toast`를 설치했어요.
- react-hot-toast는 사용하는 곳이 많아 유틸 함수로 분리했어요.
- 댓글 조회, 추가와 관련된 api와 쿼리훅을 추가했어요.
- 댓글 스토어에서 더미 댓글을 사용하지 않고 실제 데이터를 사용하고 댓글의 개수를 받아요.
- 댓글 입력 추가 폼 컴포넌트를 제작해 실제로 db에 저장되도록 했어요.

## 📂 References

https://github.com/user-attachments/assets/6362b132-a593-4c3e-913f-6761ca236b01

## 💞 Review Requirements

- 파일 변경사항 및 추가사항이 많아서 읽기 힘드실 것 같아요,, 
