### PR TITLE
feat: 영상 상세 페이지에서 동영상 url에 따른 임베드 (#81)

### DIFF
--- a/src/components/video/EmbedYoutubeVideo.tsx
+++ b/src/components/video/EmbedYoutubeVideo.tsx
@@ -1,0 +1,34 @@
+import YouTube from 'react-youtube';
+
+import { getYoutubeVideoId } from '@/utils/getYoutubeVideoId';
+import { cn } from '@/utils/cn';
+
+type EmbedYoutubeVideoProps = {
+  videoUrl: string;
+  className?: string;
+};
+
+const EmbedYoutubeVideo = ({ videoUrl, className }: EmbedYoutubeVideoProps) => {
+  const videoOption = {
+    width: '100%',
+    height: '100%',
+  };
+
+  return (
+    <figure
+      className={cn(
+        'relative aspect-video w-full overflow-hidden rounded-lg',
+        className,
+      )}
+    >
+      <YouTube
+        videoId={getYoutubeVideoId(videoUrl)}
+        title="youtube 동영상"
+        opts={videoOption}
+        className="absolute inset-0"
+      />
+    </figure>
+  );
+};
+
+export default EmbedYoutubeVideo;

--- a/src/components/video/VideoItem.tsx
+++ b/src/components/video/VideoItem.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 
 import VideoStats from './VideoStats';
+import EmbedYoutubeVideo from './EmbedYoutubeVideo';
 import SimpleProfile from '../common/simple-profile/SimpleProfile';
 import Button from '../common/button/Button';
 import { mockUsers } from '@/mocks/mockUsers';
@@ -8,6 +9,7 @@ import { VideoProps } from '@/types/video';
 
 const VideoItem = ({
   thumbnail,
+  video_url,
   title,
   user_id,
   hash_tag,
@@ -19,11 +21,18 @@ const VideoItem = ({
 }: VideoProps) => {
   const userData = mockUsers.find(user => user.user_id === user_id);
 
-  const ThumbnailContent = (
-    <figure className="relative mb-3 aspect-video w-full overflow-hidden rounded-lg">
-      <img src={thumbnail} alt={title} className="h-full w-full object-cover" />
-    </figure>
-  );
+  const ThumbnailContent =
+    isVideoDetailPage && video_url ? (
+      <EmbedYoutubeVideo videoUrl={video_url} className="mb-3" />
+    ) : (
+      <figure className="relative mb-3 aspect-video w-full overflow-hidden rounded-lg">
+        <img
+          src={thumbnail}
+          alt={title}
+          className="h-full w-full object-cover"
+        />
+      </figure>
+    );
 
   const TitleContent = (
     <h2 className="text-base font-bold text-black">{title}</h2>

--- a/src/components/video/VideoUploadBox.tsx
+++ b/src/components/video/VideoUploadBox.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import YouTube from 'react-youtube';
+
+import EmbedYoutubeVideo from './EmbedYoutubeVideo';
 import LabelInput from '../common/label-input/LabelInput';
 import Button from '../common/button/Button';
-import { YOUTUBE_REGEX } from '@/constants/constants';
 
 type VideoUploadBoxProps = {
   isEditPage?: boolean;
@@ -12,35 +12,17 @@ const VideoUploadBox = (videoUploadProps: VideoUploadBoxProps) => {
   const [youTubeUrl, setYouTubeUrl] = useState('');
   const [isClick, setIsClick] = useState(false);
 
-  const videoOption = {
-    width: '100%',
-  };
-
-  const findVideoId = (url: string) => {
-    const matchURL = url.match(YOUTUBE_REGEX.URL);
-    const matchShortUrl = url.match(YOUTUBE_REGEX.SHORT_URL);
-    if (matchURL !== null) {
-      return matchURL[0];
-    } else if (matchShortUrl !== null) {
-      return matchShortUrl[0];
-    }
-  };
   const clickVideoUpload = () => {
     setIsClick(true);
   };
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setIsClick(false);
     setYouTubeUrl(e.target.value);
   };
 
   if (videoUploadProps.isEditPage) {
-    return (
-      <YouTube
-        videoId={findVideoId(youTubeUrl)}
-        title="youtube 동영상"
-        opts={videoOption}
-      />
-    );
+    return <EmbedYoutubeVideo videoUrl={youTubeUrl} />;
   }
   return (
     <section className="flex flex-col gap-2">
@@ -60,11 +42,7 @@ const VideoUploadBox = (videoUploadProps: VideoUploadBoxProps) => {
             </Button>
           </div>
         ) : (
-          <YouTube
-            videoId={findVideoId(youTubeUrl)}
-            title="youtube 동영상"
-            opts={videoOption}
-          />
+          <EmbedYoutubeVideo videoUrl={youTubeUrl} />
         )}
       </>
     </section>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -29,4 +29,5 @@ const YOUTUBE_REGEX = {
   URL: /(?<=v=)([^?]+)?/g,
   SHORT_URL: /(?<=youtu\.be\/)([^?]+)?/g,
 };
+
 export { ROUTER_PATH, NAVIGATION_BAR, YOUTUBE_REGEX };

--- a/src/utils/getYoutubeVideoId.ts
+++ b/src/utils/getYoutubeVideoId.ts
@@ -1,9 +1,9 @@
 import { YOUTUBE_REGEX } from '@/constants/constants';
 
-const getYoutubeVideoUrl = (url: string) => {
+const getYoutubeVideoId = (url: string) => {
   const urlMatch = url.match(YOUTUBE_REGEX.URL);
   const shortUrlMatch = url.match(YOUTUBE_REGEX.SHORT_URL);
   return urlMatch?.[0] || shortUrlMatch?.[0] || null;
 };
 
-export { getYoutubeVideoUrl };
+export { getYoutubeVideoId };

--- a/src/utils/getYoutubeVideoId.ts
+++ b/src/utils/getYoutubeVideoId.ts
@@ -1,0 +1,9 @@
+import { YOUTUBE_REGEX } from '@/constants/constants';
+
+const getYoutubeVideoUrl = (url: string) => {
+  const urlMatch = url.match(YOUTUBE_REGEX.URL);
+  const shortUrlMatch = url.match(YOUTUBE_REGEX.SHORT_URL);
+  return urlMatch?.[0] || shortUrlMatch?.[0] || null;
+};
+
+export { getYoutubeVideoUrl };


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #81 

## ✅ Task Details

- 유튜브 영상 id 값을 찾는 유틸 함수를 추가했어요.
- 유튜브 영상 임베드하는 컴포넌트를 따로 만들었어요.
- 기존에 영상 추가하는 곳에 있던 컴포넌트를 수정했어요.
- 영상 상세 페이지에 영상 임베드를 적용했어요.

## 📂 References

https://github.com/user-attachments/assets/40d8811c-8e01-4f76-b87f-42f1ee53b4e7

## 💞 Review Requirements

- 리뷰 요구사항을 적어주세요!
