### PR TITLE
feat: 인증되지 않은 유저는 인가되지 않도록 보호된 라우터 구성 (#87)

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,4 +1,4 @@
-import { supabase } from './Supabase';
+import { supabase } from './supabase';
 import { UserProps, UpdateData } from '@/types/user';
 
 // 모든 사용자 조회

--- a/src/components/common/spinner/Spinner.tsx
+++ b/src/components/common/spinner/Spinner.tsx
@@ -1,0 +1,9 @@
+const Spinner = () => {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-12 w-12 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+    </div>
+  );
+};
+
+export default Spinner;

--- a/src/components/empty/EmptyResult.tsx
+++ b/src/components/empty/EmptyResult.tsx
@@ -6,9 +6,9 @@ type EmptyResultProps = {
 
 const EmptyResult = ({ message }: EmptyResultProps) => {
   return (
-    <main className="mt-10 flex flex-col items-center justify-center">
-      <img src={emptySvg} alt="검색 결과가 없습니다." className="w-32" />
-      <p className="text-center">{message}</p>
+    <main className="my-10 flex flex-col items-center justify-center">
+      <img src={emptySvg} alt="검색 결과가 없습니다." className="w-24" />
+      <p className="text-center text-sm">{message}</p>
     </main>
   );
 };

--- a/src/components/my-page/MyPageProfile.tsx
+++ b/src/components/my-page/MyPageProfile.tsx
@@ -15,7 +15,7 @@ const MyPageProfile = (props: { userData: UserProps }) => {
           <img
             src={userData.user_image}
             alt="프로필 사진"
-            className="w-ull h-full object-cover"
+            className="h-full w-full object-cover"
           />
         </div>
         <div className="flex flex-col justify-center gap-2 font-bold">

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -4,11 +4,13 @@ import NavigationBar from '@/components/navigation-bar/NavigationBar';
 import LogoHeader from '@/components/header/LogoHeader';
 import BackHeader from '@/components/header/BackHeader';
 import ScrollToTop from '@/components/common/scroll/ScrollToTop';
+import { useUsers } from '@/hooks/useUsers';
 import { ROUTER_PATH } from '@/constants/constants';
 import { cn } from '@/utils/cn';
 
 const Layout = () => {
   const { pathname } = useLocation();
+  const { currentUserQuery } = useUsers();
 
   const isLoginPage = pathname === ROUTER_PATH.LOGIN;
   const isSplashPage = pathname === ROUTER_PATH.SPLASH;
@@ -17,7 +19,10 @@ const Layout = () => {
     ROUTER_PATH.GOOGLE_REDIRECT,
   ].includes(pathname);
   const shouldHideHeaderAndNav =
-    isLoginPage || isSplashPage || isOAuthRedirectPage;
+    isLoginPage ||
+    isSplashPage ||
+    isOAuthRedirectPage ||
+    currentUserQuery.isLoading;
 
   const shouldShowBackButton = [
     ROUTER_PATH.MY_PAGE_EDIT,
@@ -35,7 +40,12 @@ const Layout = () => {
       <section className="relative w-full max-w-container bg-white">
         {!shouldHideHeaderAndNav &&
           (shouldShowBackButton ? <BackHeader /> : <LogoHeader />)}
-        <div className={cn('px-3', !shouldHideHeaderAndNav && 'pb-28')}>
+        <div
+          className={cn(
+            !isOAuthRedirectPage && 'px-3',
+            !shouldHideHeaderAndNav && 'pb-28',
+          )}
+        >
           <Outlet />
         </div>
         {!shouldHideHeaderAndNav && <NavigationBar />}

--- a/src/pages/SplashPage.tsx
+++ b/src/pages/SplashPage.tsx
@@ -4,19 +4,20 @@ import { useNavigate } from 'react-router-dom';
 
 import MainLogoHeader from '@/components/header/MainLogoHeader';
 import { ROUTER_PATH } from '@/constants/constants';
+import { useUsers } from '@/hooks/useUsers';
 
 const SplashPage = () => {
-  const isLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
+  const { currentUserQuery } = useUsers();
   const { HOME, LOGIN } = ROUTER_PATH;
   const navigate = useNavigate();
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      navigate(isLoggedIn ? HOME : LOGIN);
+      navigate(currentUserQuery.data ? HOME : LOGIN);
     }, 1000);
 
     return () => clearTimeout(timer);
-  }, [isLoggedIn, navigate, HOME, LOGIN]);
+  }, [currentUserQuery.data, navigate, HOME, LOGIN]);
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center">

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -77,10 +77,10 @@ const MyPage = () => {
       <section>
         <p className="text-lg font-bold">내가 시청한 동영상</p>
         <hr className="my-2" aria-hidden="true" />
-        {!watchedVideos ? (
-          <EmptyResult message="영상이 아무것도 없어요!" />
+        {watchedVideos?.length === 0 ? (
+          <EmptyResult message="시청 영상이 없어요!" />
         ) : (
-          <WatchedVideoList videos={watchedVideos} />
+          <WatchedVideoList videos={watchedVideos!} />
         )}
       </section>
 
@@ -92,10 +92,10 @@ const MyPage = () => {
           </Link>
         </div>
         <hr className="my-2" aria-hidden="true" />
-        {!uploadVideos ? (
-          <EmptyResult message="영상이 아무것도 없어요!" />
+        {uploadVideos?.length === 0 ? (
+          <EmptyResult message="업로드한 영상이 없어요!" />
         ) : (
-          <MyPageUploadVideoList videos={uploadVideos} />
+          <MyPageUploadVideoList videos={uploadVideos!} />
         )}
       </section>
 

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,24 @@
+import { Navigate, useLocation } from 'react-router-dom';
+
+import Spinner from '@/components/common/spinner/Spinner';
+import { useUsers } from '@/hooks/useUsers';
+import { ROUTER_PATH } from '@/constants/constants';
+
+const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
+  const { currentUserQuery } = useUsers();
+  const location = useLocation();
+
+  if (currentUserQuery.isLoading) {
+    return <Spinner />;
+  }
+
+  if (!currentUserQuery.data) {
+    return (
+      <Navigate to={ROUTER_PATH.LOGIN} state={{ from: location }} replace />
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,5 +1,6 @@
-import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import { RouterProvider, createBrowserRouter, Outlet } from 'react-router-dom';
 
+import ProtectedRoute from './ProtectedRoute';
 import Layout from '@/layout/Layout';
 import SplashPage from '@/pages/SplashPage';
 import HomePage from '@/pages/HomePage';
@@ -48,9 +49,21 @@ const Router = () => {
         { path: KAKAO_REDIRECT, element: <KakaoOAuthHandler /> },
         { path: GOOGLE_REDIRECT, element: <GoogleOAuthHandler /> },
         { path: LOGIN, element: <LoginPage /> },
-        { path: HOME, element: <HomePage /> },
+        {
+          path: HOME,
+          element: (
+            <ProtectedRoute>
+              <HomePage />
+            </ProtectedRoute>
+          ),
+        },
         {
           path: MY_PAGE,
+          element: (
+            <ProtectedRoute>
+              <Outlet />
+            </ProtectedRoute>
+          ),
           children: [
             { index: true, element: <MyPage /> },
             { path: MY_PAGE_EDIT, element: <MyPageEdit /> },
@@ -60,15 +73,32 @@ const Router = () => {
         },
         {
           path: PLAYLIST,
+          element: (
+            <ProtectedRoute>
+              <Outlet />
+            </ProtectedRoute>
+          ),
           children: [
             { index: true, element: <PlayListPage /> },
             { path: PLAYLIST_DETAIL, element: <PlayListDetailPage /> },
           ],
         },
-        { path: VIDEO_ADD, element: <VideoAddPage /> },
+        {
+          path: VIDEO_ADD,
+          element: (
+            <ProtectedRoute>
+              <VideoAddPage />
+            </ProtectedRoute>
+          ),
+        },
         { path: VIDEO_DETAIL, element: <VideoDetailPage /> },
         {
           path: BOOKMARK,
+          element: (
+            <ProtectedRoute>
+              <Outlet />
+            </ProtectedRoute>
+          ),
           children: [
             { index: true, element: <BookmarkPage /> },
             {
@@ -77,8 +107,22 @@ const Router = () => {
             },
           ],
         },
-        { path: AUTHOR_DETAIL, element: <AuthorDetailPage /> },
-        { path: '*', element: <NotFoundPage /> },
+        {
+          path: AUTHOR_DETAIL,
+          element: (
+            <ProtectedRoute>
+              <AuthorDetailPage />
+            </ProtectedRoute>
+          ),
+        },
+        {
+          path: '*',
+          element: (
+            <ProtectedRoute>
+              <NotFoundPage />
+            </ProtectedRoute>
+          ),
+        },
       ],
     },
   ]);

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -91,7 +91,14 @@ const Router = () => {
             </ProtectedRoute>
           ),
         },
-        { path: VIDEO_DETAIL, element: <VideoDetailPage /> },
+        {
+          path: VIDEO_DETAIL,
+          element: (
+            <ProtectedRoute>
+              <VideoDetailPage />
+            </ProtectedRoute>
+          ),
+        },
         {
           path: BOOKMARK,
           element: (


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #87 

## ✅ Task Details

- 마이페이지에서 스타일 오탈자를 수정했어요. 
- 마이페이지에서 정보가 없을 경우의 로직을 수정했어요.
- EmptyResult 컴포넌트에서 스타일의 크기를 줄였어요.
- 현재 유저 정보가 없어 로딩 중일 때를 대비해 로딩 스피너를 추가했어요.
- 보호된 라우터 컴포넌트를 추가하여 인증이 되지 않았으면 url 입력으로 이동할 수 없도록 했어요.

## 📂 References

https://github.com/user-attachments/assets/5470841e-1370-4cc4-a276-1599daf56299

## 💞 Review Requirements

위 영상은 로그인 정보가 없을 경우 임의로 url을 타고 들어가려 할 때의 화면입니다. 유저 정보를 가져오는 데 시간이 걸려서 로딩 스피너를 추가했어요. 원래는 헤더와 하단 네비게이션바도 나왔는데 모든 것을 차단하고자 layout에 예외처리 해줬어요!
