### PR TITLE
feat: embedYoutubeVideo를 플레이리스트 상세 페이지에 적용 (#96)

### DIFF
--- a/src/components/playlist/PlayList.tsx
+++ b/src/components/playlist/PlayList.tsx
@@ -32,6 +32,7 @@ const StrictModeDroppable = ({ children, ...props }: DroppableProps) => {
 const PlayList = ({
   object,
   onThumbnailChange,
+  onVideoUrlChange,
   thumbnail,
 }: PlayListVideoProps) => {
   const initialVideoList = object?.categoried_videos || [];
@@ -91,6 +92,7 @@ const PlayList = ({
                         video={video}
                         thumbnail={thumbnail}
                         onThumbnailChange={onThumbnailChange ?? (() => {})}
+                        onVideoUrlChange={onVideoUrlChange ?? (() => {})}
                         userData={userData}
                       />
                     </div>

--- a/src/components/playlist/PlayList.tsx
+++ b/src/components/playlist/PlayList.tsx
@@ -29,12 +29,7 @@ const StrictModeDroppable = ({ children, ...props }: DroppableProps) => {
   return <Droppable {...props}>{children}</Droppable>;
 };
 
-const PlayList = ({
-  object,
-  onThumbnailChange,
-  onVideoUrlChange,
-  thumbnail,
-}: PlayListVideoProps) => {
+const PlayList = ({ object, onVideoUrlChange }: PlayListVideoProps) => {
   const initialVideoList = object?.categoried_videos || [];
   const [videoList, setVideoList] = useState(initialVideoList);
 
@@ -90,8 +85,6 @@ const PlayList = ({
                     >
                       <PlayListItem
                         video={video}
-                        thumbnail={thumbnail}
-                        onThumbnailChange={onThumbnailChange ?? (() => {})}
                         onVideoUrlChange={onVideoUrlChange ?? (() => {})}
                         userData={userData}
                       />

--- a/src/components/playlist/PlayListItem.tsx
+++ b/src/components/playlist/PlayListItem.tsx
@@ -8,6 +8,8 @@ type PlayListItemProps = {
   thumbnail: string;
   // eslint-disable-next-line no-unused-vars
   onThumbnailChange: (thumbnail: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  onVideoUrlChange: (videoUrl: string) => void;
   userData?: UserProps;
 };
 
@@ -15,6 +17,7 @@ const PlayListItem = ({
   video,
   thumbnail,
   onThumbnailChange,
+  onVideoUrlChange,
   userData,
 }: PlayListItemProps) => {
   const { videoQuery } = useVideos(video);
@@ -32,6 +35,7 @@ const PlayListItem = ({
           )}
           onClick={() => {
             onThumbnailChange(videoData.thumbnail);
+            onVideoUrlChange(videoData.video_url);
           }}
         >
           <figure className="relative flex h-full w-32 items-center">

--- a/src/components/playlist/PlayListItem.tsx
+++ b/src/components/playlist/PlayListItem.tsx
@@ -5,9 +5,6 @@ import { useVideos } from '@/hooks/useVideos';
 
 type PlayListItemProps = {
   video: string;
-  thumbnail: string;
-  // eslint-disable-next-line no-unused-vars
-  onThumbnailChange: (thumbnail: string) => void;
   // eslint-disable-next-line no-unused-vars
   onVideoUrlChange: (videoUrl: string) => void;
   userData?: UserProps;
@@ -15,8 +12,6 @@ type PlayListItemProps = {
 
 const PlayListItem = ({
   video,
-  thumbnail,
-  onThumbnailChange,
   onVideoUrlChange,
   userData,
 }: PlayListItemProps) => {
@@ -29,12 +24,8 @@ const PlayListItem = ({
       {videoData && (
         <div
           key={videoData.video_id}
-          className={cn(
-            'flex cursor-pointer items-center gap-2',
-            videoData.thumbnail === thumbnail ? 'bg-gray-300' : '',
-          )}
+          className={cn('flex cursor-pointer items-center gap-2')}
           onClick={() => {
-            onThumbnailChange(videoData.thumbnail);
             onVideoUrlChange(videoData.video_url);
           }}
         >

--- a/src/components/playlist/PlayListVideo.tsx
+++ b/src/components/playlist/PlayListVideo.tsx
@@ -2,8 +2,9 @@ import { getTimeAgo } from '@/utils/getTimeAgo';
 import { IoHeartOutline, IoHeartSharp } from 'react-icons/io5';
 import { LuTableOfContents } from 'react-icons/lu';
 import type { PlayListVideoProps } from '@/types/playList';
+import EmbedYoutubeVideo from '@/components/video/EmbedYoutubeVideo';
 
-const PlayListVideo = ({ object, thumbnail }: PlayListVideoProps) => {
+const PlayListVideo = ({ object, thumbnail, videoUrl }: PlayListVideoProps) => {
   if (!object) {
     return;
   }
@@ -14,13 +15,17 @@ const PlayListVideo = ({ object, thumbnail }: PlayListVideoProps) => {
 
   return (
     <div className="sticky top-0 z-10 mb-2 bg-white">
-      <figure className="relative mb-3 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
-        <img
-          src={thumbnail ? thumbnail : object.category_thumbnail}
-          alt={object.title}
-          className="h-full w-full object-cover"
-        />
-      </figure>
+      {videoUrl ? (
+        <EmbedYoutubeVideo videoUrl={videoUrl} />
+      ) : (
+        <figure className="relative mb-3 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
+          <img
+            src={thumbnail ? thumbnail : object.category_thumbnail}
+            alt={object.title}
+            className="h-full w-full object-cover"
+          />
+        </figure>
+      )}
 
       <div className="flex w-full flex-row justify-between gap-1">
         <div className="relative flex w-[90%] flex-row overflow-hidden whitespace-nowrap">

--- a/src/components/playlist/PlayListVideo.tsx
+++ b/src/components/playlist/PlayListVideo.tsx
@@ -16,7 +16,7 @@ const PlayListVideo = ({ object, videoUrl }: PlayListVideoProps) => {
   return (
     <div className="sticky top-0 z-10 mb-2 bg-white">
       {videoUrl ? (
-        <EmbedYoutubeVideo videoUrl={videoUrl} />
+        <EmbedYoutubeVideo videoUrl={videoUrl} className="mb-3" />
       ) : (
         <figure className="relative mb-3 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
           <img

--- a/src/components/playlist/PlayListVideo.tsx
+++ b/src/components/playlist/PlayListVideo.tsx
@@ -4,7 +4,7 @@ import { LuTableOfContents } from 'react-icons/lu';
 import type { PlayListVideoProps } from '@/types/playList';
 import EmbedYoutubeVideo from '@/components/video/EmbedYoutubeVideo';
 
-const PlayListVideo = ({ object, thumbnail, videoUrl }: PlayListVideoProps) => {
+const PlayListVideo = ({ object, videoUrl }: PlayListVideoProps) => {
   if (!object) {
     return;
   }
@@ -20,7 +20,7 @@ const PlayListVideo = ({ object, thumbnail, videoUrl }: PlayListVideoProps) => {
       ) : (
         <figure className="relative mb-3 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
           <img
-            src={thumbnail ? thumbnail : object.category_thumbnail}
+            src={object.category_thumbnail}
             alt={object.title}
             className="h-full w-full object-cover"
           />

--- a/src/pages/playlist/PlayListDetailPage.tsx
+++ b/src/pages/playlist/PlayListDetailPage.tsx
@@ -11,7 +11,7 @@ import { useMusics } from '@/hooks/useMusics';
 const PlayListDetailPage = () => {
   const { playlistId } = useParams();
   const [thumbnail, setThumbnail] = useState('');
-
+  const [videoUrl, setVideoUrl] = useState('');
   const { videosQuery } = useVideos();
   const categoriesQuery = useCategories('user1');
   const musicsQuery = useMusics();
@@ -54,15 +54,24 @@ const PlayListDetailPage = () => {
     setThumbnail(newThumbnail);
   };
 
+  const handleVideoUrlChange = (newVideoUrl: string) => {
+    setVideoUrl(newVideoUrl); // 업데이트된 videoUrl 저장
+  };
+
   if (filteredPlayLists.length > 0) {
     return (
       <>
         {filteredPlayLists.map(playlist => (
           <div key={playlist.list_id}>
-            <PlayListVideo object={playlist} thumbnail={thumbnail} />
+            <PlayListVideo
+              object={playlist}
+              thumbnail={thumbnail}
+              videoUrl={videoUrl}
+            />
             <PlayList
               object={playlist}
               onThumbnailChange={handleThumbnailChange}
+              onVideoUrlChange={handleVideoUrlChange}
               thumbnail={thumbnail}
             />
           </div>
@@ -74,10 +83,15 @@ const PlayListDetailPage = () => {
       <>
         {filteredMusics.map(music => (
           <div key={music.list_id}>
-            <PlayListVideo object={music} thumbnail={thumbnail} />
+            <PlayListVideo
+              object={music}
+              thumbnail={thumbnail}
+              videoUrl={videoUrl}
+            />
             <PlayList
               object={music}
               onThumbnailChange={handleThumbnailChange}
+              onVideoUrlChange={handleVideoUrlChange}
               thumbnail={thumbnail}
             />
           </div>

--- a/src/pages/playlist/PlayListDetailPage.tsx
+++ b/src/pages/playlist/PlayListDetailPage.tsx
@@ -10,7 +10,6 @@ import { useMusics } from '@/hooks/useMusics';
 
 const PlayListDetailPage = () => {
   const { playlistId } = useParams();
-  const [thumbnail, setThumbnail] = useState('');
   const [videoUrl, setVideoUrl] = useState('');
   const { videosQuery } = useVideos();
   const categoriesQuery = useCategories('user1');
@@ -50,10 +49,6 @@ const PlayListDetailPage = () => {
     },
   );
 
-  const handleThumbnailChange = (newThumbnail: string) => {
-    setThumbnail(newThumbnail);
-  };
-
   const handleVideoUrlChange = (newVideoUrl: string) => {
     setVideoUrl(newVideoUrl); // 업데이트된 videoUrl 저장
   };
@@ -63,16 +58,10 @@ const PlayListDetailPage = () => {
       <>
         {filteredPlayLists.map(playlist => (
           <div key={playlist.list_id}>
-            <PlayListVideo
-              object={playlist}
-              thumbnail={thumbnail}
-              videoUrl={videoUrl}
-            />
+            <PlayListVideo object={playlist} videoUrl={videoUrl} />
             <PlayList
               object={playlist}
-              onThumbnailChange={handleThumbnailChange}
               onVideoUrlChange={handleVideoUrlChange}
-              thumbnail={thumbnail}
             />
           </div>
         ))}
@@ -83,17 +72,8 @@ const PlayListDetailPage = () => {
       <>
         {filteredMusics.map(music => (
           <div key={music.list_id}>
-            <PlayListVideo
-              object={music}
-              thumbnail={thumbnail}
-              videoUrl={videoUrl}
-            />
-            <PlayList
-              object={music}
-              onThumbnailChange={handleThumbnailChange}
-              onVideoUrlChange={handleVideoUrlChange}
-              thumbnail={thumbnail}
-            />
+            <PlayListVideo object={music} videoUrl={videoUrl} />
+            <PlayList object={music} onVideoUrlChange={handleVideoUrlChange} />
           </div>
         ))}
       </>

--- a/src/types/playList.ts
+++ b/src/types/playList.ts
@@ -15,10 +15,7 @@ type PlayListProps = {
 type PlayListVideoProps = {
   object: PlayListProps;
   // eslint-disable-next-line no-unused-vars
-  onThumbnailChange?: (thumbnail: string) => void;
-  // eslint-disable-next-line no-unused-vars
   onVideoUrlChange?: (videoUrl: string) => void;
-  thumbnail: string;
   videoUrl?: string;
   updated_at?: Date;
 };

--- a/src/types/playList.ts
+++ b/src/types/playList.ts
@@ -16,7 +16,10 @@ type PlayListVideoProps = {
   object: PlayListProps;
   // eslint-disable-next-line no-unused-vars
   onThumbnailChange?: (thumbnail: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  onVideoUrlChange?: (videoUrl: string) => void;
   thumbnail: string;
+  videoUrl?: string;
   updated_at?: Date;
 };
 


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 [#96 ]

## ✅ Task Details

- embedYoutubeVideo를 플레이리스트 상세 페이지에 적용

## 📂 References


https://github.com/user-attachments/assets/7ec806f0-f942-42c8-98db-f9d03fb968a9


## 💞 Review Requirements

-  videoUrl이 존재하지 않다면 썸네일을, 존재한다면 embedYoutubeVideo를 출력하게 했습니다.
- 기존의 구현되어있는 컴폰너트를 사용만하면 되어서 감사드립니다
- 생각해보니 thumbnail 관련 props는 사용하지 않는 것 같아서 제거하겠습니당
- css 관련 속성 적용했습니다
