### PR TITLE
feat: 동영상 업로드 페이지 기능 구현 및 supabse연동 (#88)

### DIFF
--- a/src/api/videos.ts
+++ b/src/api/videos.ts
@@ -1,3 +1,4 @@
+import { UploadVideoProps } from '@/types/video';
 import { supabase } from './supabase';
 
 // 모든 영상 조회
@@ -20,11 +21,23 @@ export async function fetchVideo(videoId: string) {
   return data;
 }
 
+// 여러 영상 조회
 export async function fetchSelectVideos(videoIds: string[]) {
   const { data, error } = await supabase
     .from('videos')
     .select('*')
     .in('video_id', videoIds);
+
+  if (error) throw error;
+  return data;
+}
+
+// 영상 추가
+export async function addVideo(newVideo: UploadVideoProps) {
+  const { data, error } = await supabase
+    .from('videos')
+    .insert(newVideo)
+    .select();
 
   if (error) throw error;
   return data;

--- a/src/components/my-page/MyPageVideoCategories.tsx
+++ b/src/components/my-page/MyPageVideoCategories.tsx
@@ -1,0 +1,51 @@
+import Button from '../common/button/Button';
+import { VideoUploadCategoryProps } from '@/types/video';
+
+const MyPageVideoCategories = (videoCategoryProp: VideoUploadCategoryProps) => {
+  const {
+    videoCategories,
+    selectedTags,
+    isAddVideoCategory,
+    addVideoCategoryValue,
+    handleAddVideoCategoryValue,
+    toggleTag,
+    addVideoCategories,
+  } = videoCategoryProp;
+  return (
+    <section className="flex flex-col gap-2">
+      <p className="text-base font-bold">해시 태그</p>
+      <nav className="flex flex-wrap gap-small">
+        {videoCategories.map((tag, index) => (
+          <Button
+            size="small"
+            variant={selectedTags.includes(tag) ? 'primary' : 'outline'}
+            key={index}
+            onClick={() => toggleTag(tag)}
+          >
+            {tag}
+          </Button>
+        ))}
+        <div>
+          {isAddVideoCategory && (
+            <input
+              type="text"
+              className="mr-4 rounded-md border border-primary py-1 text-xs text-black"
+              value={addVideoCategoryValue}
+              onChange={handleAddVideoCategoryValue}
+            />
+          )}
+          <Button
+            key="addHashTag"
+            size="small"
+            variant="outline"
+            onClick={addVideoCategories}
+          >
+            {!isAddVideoCategory ? '추가 입력' : '카테고리 추가'}
+          </Button>
+        </div>
+      </nav>
+    </section>
+  );
+};
+
+export default MyPageVideoCategories;

--- a/src/components/thumbnail/ThumbnailUpload.tsx
+++ b/src/components/thumbnail/ThumbnailUpload.tsx
@@ -45,7 +45,8 @@ const ThumbnailUpload = ({
           <img
             src={imgFile}
             alt="프로필 이미지"
-            className="h-full w-full object-cover"
+            className="h-full w-full cursor-pointer object-cover"
+            onClick={handleInput}
           />
         ) : (
           <div className="flex aspect-video flex-col items-center justify-center bg-gray-100 p-medium shadow-inner">

--- a/src/components/video/VideoUploadBox.tsx
+++ b/src/components/video/VideoUploadBox.tsx
@@ -6,10 +6,13 @@ import Button from '../common/button/Button';
 
 type VideoUploadBoxProps = {
   isEditPage?: boolean;
-  videoURL?: string;
+
+  videoURL: string;
+
+  setVideoURL: React.Dispatch<React.SetStateAction<string>>;
 };
 const VideoUploadBox = (videoUploadProps: VideoUploadBoxProps) => {
-  const [youTubeUrl, setYouTubeUrl] = useState('');
+  const { isEditPage, videoURL, setVideoURL } = videoUploadProps;
   const [isClick, setIsClick] = useState(false);
 
   const clickVideoUpload = () => {
@@ -18,11 +21,11 @@ const VideoUploadBox = (videoUploadProps: VideoUploadBoxProps) => {
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setIsClick(false);
-    setYouTubeUrl(e.target.value);
+    setVideoURL(e.target.value);
   };
 
-  if (videoUploadProps.isEditPage) {
-    return <EmbedYoutubeVideo videoUrl={youTubeUrl} />;
+  if (isEditPage) {
+    return <EmbedYoutubeVideo videoUrl={videoURL} />;
   }
   return (
     <section className="flex flex-col gap-2">
@@ -30,7 +33,7 @@ const VideoUploadBox = (videoUploadProps: VideoUploadBoxProps) => {
         <LabelInput
           title="영상URL"
           placeholder="원하는 동영상의 URL을 입력해주세요"
-          value={youTubeUrl}
+          value={videoURL}
           onChange={handleInputChange}
         />
       </header>
@@ -42,7 +45,7 @@ const VideoUploadBox = (videoUploadProps: VideoUploadBoxProps) => {
             </Button>
           </div>
         ) : (
-          <EmbedYoutubeVideo videoUrl={youTubeUrl} />
+          <EmbedYoutubeVideo videoUrl={videoURL} />
         )}
       </>
     </section>

--- a/src/components/video/VideoUploadBox.tsx
+++ b/src/components/video/VideoUploadBox.tsx
@@ -6,9 +6,7 @@ import Button from '../common/button/Button';
 
 type VideoUploadBoxProps = {
   isEditPage?: boolean;
-
   videoURL: string;
-
   setVideoURL: React.Dispatch<React.SetStateAction<string>>;
 };
 const VideoUploadBox = (videoUploadProps: VideoUploadBoxProps) => {
@@ -40,7 +38,11 @@ const VideoUploadBox = (videoUploadProps: VideoUploadBoxProps) => {
       <>
         {!isClick ? (
           <div className="flex aspect-video flex-col items-center justify-center rounded-medium bg-gray-100 p-medium shadow-inner">
-            <Button className="text-nowrap" onClick={clickVideoUpload}>
+            <Button
+              className="text-nowrap"
+              onClick={clickVideoUpload}
+              disabled={!videoURL}
+            >
               영상 확인하기
             </Button>
           </div>

--- a/src/hooks/useSelectImage.ts
+++ b/src/hooks/useSelectImage.ts
@@ -19,6 +19,9 @@ export const useSelectImage = (onImageChange: (file: string) => void) => {
   };
 
   const handleInput = () => {
+    if (imgRef.current) {
+      imgRef.current.value = '';
+    }
     imgRef.current?.click();
   };
 

--- a/src/hooks/useVideoCategories.ts
+++ b/src/hooks/useVideoCategories.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 const useVideoCategories = (basicVideoCategories: string[]) => {
   const [selectedTags, setSelectedTags] = useState<string[]>([]); //선택된 태그
-  const [videoCategories, setVideoCategories] =
+  const [videoCategoryList, setVideoCategoryList] =
     useState<string[]>(basicVideoCategories); // 태그 리스트
   const [isAddVideoCategory, setIsAddVideoCategory] = useState(false); // 태그 추가 상태
   const [addVideoCategoryValue, setAddVideoCategoryValue] = useState(''); // 태그 추가 input 핸들러
@@ -22,7 +22,7 @@ const useVideoCategories = (basicVideoCategories: string[]) => {
   //태그 추가
   const addVideoCategories = () => {
     if (isAddVideoCategory && addVideoCategoryValue) {
-      videoCategories.push(addVideoCategoryValue);
+      videoCategoryList.push(addVideoCategoryValue);
       setAddVideoCategoryValue('');
     }
     setIsAddVideoCategory(!isAddVideoCategory);
@@ -32,12 +32,12 @@ const useVideoCategories = (basicVideoCategories: string[]) => {
     selectedTags,
     isAddVideoCategory,
     addVideoCategoryValue,
-    videoCategories,
+    videoCategoryList,
     toggleTag,
     setSelectedTags,
     addVideoCategories,
     handleAddVideoCategoryValue,
-    setVideoCategories,
+    setVideoCategoryList,
     setIsAddVideoCategory,
     setAddVideoCategoryValue,
   };

--- a/src/hooks/useVideoCategories.ts
+++ b/src/hooks/useVideoCategories.ts
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+const useVideoCategories = (basicVideoCategories: string[]) => {
+  const [selectedTags, setSelectedTags] = useState<string[]>([]); //선택된 태그
+  const [videoCategories, setVideoCategories] =
+    useState<string[]>(basicVideoCategories); // 태그 리스트
+  const [isAddVideoCategory, setIsAddVideoCategory] = useState(false); // 태그 추가 상태
+  const [addVideoCategoryValue, setAddVideoCategoryValue] = useState(''); // 태그 추가 input 핸들러
+
+  // 태그 선택
+  const toggleTag = (tag: string) => {
+    setSelectedTags(prev =>
+      prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag],
+    );
+  };
+  //태그 추가 input 핸들러
+  const handleAddVideoCategoryValue = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setAddVideoCategoryValue(e.target.value);
+  };
+  //태그 추가
+  const addVideoCategories = () => {
+    if (isAddVideoCategory && addVideoCategoryValue) {
+      videoCategories.push(addVideoCategoryValue);
+      setAddVideoCategoryValue('');
+    }
+    setIsAddVideoCategory(!isAddVideoCategory);
+  };
+
+  return {
+    selectedTags,
+    isAddVideoCategory,
+    addVideoCategoryValue,
+    videoCategories,
+    toggleTag,
+    setSelectedTags,
+    addVideoCategories,
+    handleAddVideoCategoryValue,
+    setVideoCategories,
+    setIsAddVideoCategory,
+    setAddVideoCategoryValue,
+  };
+};
+
+export { useVideoCategories };

--- a/src/hooks/useVideos.tsx
+++ b/src/hooks/useVideos.tsx
@@ -9,7 +9,7 @@ import {
 import { UploadVideoProps } from '@/types/video';
 import { useUsers } from './useUsers';
 import { useNavigate } from 'react-router-dom';
-import { toastSuccess } from '@/utils/toast';
+import { toastError, toastSuccess } from '@/utils/toast';
 
 const useVideos = (videoId?: string, videosId?: string[]) => {
   const navigate = useNavigate();
@@ -59,12 +59,12 @@ const useVideos = (videoId?: string, videosId?: string[]) => {
         created_at: new Date(),
       }),
     onSuccess: () => {
-      toastSuccess('업로드 성공!');
+      toastSuccess('업로드에 성공했어요!');
       navigate('/home');
     },
     onError: (error: Error) => {
       console.error('업로드 실패:', error);
-      alert('동영상 업로드 중 오류가 발생했습니다.');
+      toastError('동영상 업로드 중 오류가 발생했습니다.');
     },
   });
   return {

--- a/src/hooks/useVideos.tsx
+++ b/src/hooks/useVideos.tsx
@@ -1,8 +1,20 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { fetchVideos, fetchVideo, fetchSelectVideos } from '@/api/videos';
+import {
+  fetchVideos,
+  fetchVideo,
+  fetchSelectVideos,
+  addVideo,
+} from '@/api/videos';
+import { UploadVideoProps } from '@/types/video';
+import { useUsers } from './useUsers';
+import { useNavigate } from 'react-router-dom';
+import { toastSuccess } from '@/utils/toast';
 
 const useVideos = (videoId?: string, videosId?: string[]) => {
+  const navigate = useNavigate();
+  const { currentUserQuery } = useUsers();
+
   const videosQuery = useQuery({
     queryKey: ['videos'],
     queryFn: fetchVideos,
@@ -36,10 +48,30 @@ const useVideos = (videoId?: string, videosId?: string[]) => {
     enabled: !!videosId,
   });
 
+  const addVideoMutation = useMutation({
+    mutationFn: (newVideo: UploadVideoProps) =>
+      addVideo({
+        ...newVideo,
+        user_id: currentUserQuery.data.user_id,
+        nickname: currentUserQuery.data.nickname,
+        like_heart: 0,
+        is_bookmarked: false,
+        created_at: new Date(),
+      }),
+    onSuccess: () => {
+      toastSuccess('업로드 성공!');
+      navigate('/home');
+    },
+    onError: (error: Error) => {
+      console.error('업로드 실패:', error);
+      alert('동영상 업로드 중 오류가 발생했습니다.');
+    },
+  });
   return {
     videosQuery,
     videoQuery,
     selectVideosQuery,
+    addVideoMutation,
   };
 };
 

--- a/src/mocks/videoCategories.ts
+++ b/src/mocks/videoCategories.ts
@@ -8,6 +8,18 @@ const videoCategories = [
   '팔',
   '엉덩이',
   '종아리',
+  '음악',
+];
+const uploadVideoCategories = [
+  '가슴',
+  '등',
+  '어깨',
+  '하체',
+  '복근',
+  '팔',
+  '엉덩이',
+  '종아리',
+  '음악',
 ];
 
-export { videoCategories };
+export { videoCategories, uploadVideoCategories };

--- a/src/mocks/videoCategories.ts
+++ b/src/mocks/videoCategories.ts
@@ -10,16 +10,5 @@ const videoCategories = [
   '종아리',
   '음악',
 ];
-const uploadVideoCategories = [
-  '가슴',
-  '등',
-  '어깨',
-  '하체',
-  '복근',
-  '팔',
-  '엉덩이',
-  '종아리',
-  '음악',
-];
 
-export { videoCategories, uploadVideoCategories };
+export { videoCategories };

--- a/src/pages/VideoAddPage.tsx
+++ b/src/pages/VideoAddPage.tsx
@@ -9,19 +9,21 @@ import { useVideoCategories } from '@/hooks/useVideoCategories';
 import { useVideos } from '@/hooks/useVideos';
 import { getYoutubeVideoId } from '@/utils/getYoutubeVideoId';
 import { VideoFormValues, videoSchema } from '@/schema/videoUploadSchema';
-import { uploadVideoCategories } from '@/mocks/videoCategories';
+import { videoCategories } from '@/mocks/videoCategories';
 
 const VideoAddPage = () => {
+  const uploadVideoCategories = [...videoCategories];
+  uploadVideoCategories.shift();
   const {
     selectedTags,
     isAddVideoCategory,
     addVideoCategoryValue,
-    videoCategories,
+    videoCategoryList,
     toggleTag,
     addVideoCategories,
     handleAddVideoCategoryValue,
     setSelectedTags,
-    setVideoCategories,
+    setVideoCategoryList,
     setIsAddVideoCategory,
     setAddVideoCategoryValue,
   } = useVideoCategories(uploadVideoCategories);
@@ -62,7 +64,7 @@ const VideoAddPage = () => {
 
   const handleReset = () => {
     reset();
-    setVideoCategories(uploadVideoCategories);
+    setVideoCategoryList(uploadVideoCategories);
     setIsAddVideoCategory(false);
     setAddVideoCategoryValue('');
     setSelectedTags([]);
@@ -82,7 +84,9 @@ const VideoAddPage = () => {
           )}
         />
         {errors.video_url && (
-          <p className="text-red-500">{errors.video_url.message}</p>
+          <p className="mt-2 text-sm text-red-500">
+            {errors.video_url.message}
+          </p>
         )}
       </section>
 
@@ -99,7 +103,9 @@ const VideoAddPage = () => {
             />
           )}
         />
-        {errors.title && <p className="text-red-500">{errors.title.message}</p>}
+        {errors.title && (
+          <p className="mt-2 text-sm text-red-500">{errors.title.message}</p>
+        )}
       </section>
 
       <section>
@@ -111,7 +117,7 @@ const VideoAddPage = () => {
               selectedTags={field.value || []}
               isAddVideoCategory={isAddVideoCategory}
               addVideoCategoryValue={addVideoCategoryValue}
-              videoCategories={videoCategories}
+              videoCategories={videoCategoryList}
               toggleTag={tag => {
                 toggleTag(tag); // 상태 업데이트
                 if (field.value?.includes(tag)) {
@@ -126,7 +132,7 @@ const VideoAddPage = () => {
           )}
         />
         {errors.hash_tag && (
-          <p className="text-red-500">{errors.hash_tag.message}</p>
+          <p className="mt-2 text-sm text-red-500">{errors.hash_tag.message}</p>
         )}
       </section>
 

--- a/src/pages/VideoAddPage.tsx
+++ b/src/pages/VideoAddPage.tsx
@@ -9,20 +9,9 @@ import { useVideoCategories } from '@/hooks/useVideoCategories';
 import { useVideos } from '@/hooks/useVideos';
 import { getYoutubeVideoId } from '@/utils/getYoutubeVideoId';
 import { VideoFormValues, videoSchema } from '@/schema/videoUploadSchema';
+import { uploadVideoCategories } from '@/mocks/videoCategories';
 
 const VideoAddPage = () => {
-  const basicVideoCategories = [
-    '가슴',
-    '등',
-    '어깨',
-    '하체',
-    '복근',
-    '팔',
-    '엉덩이',
-    '종아리',
-    '음악',
-  ];
-
   const {
     selectedTags,
     isAddVideoCategory,
@@ -35,7 +24,7 @@ const VideoAddPage = () => {
     setVideoCategories,
     setIsAddVideoCategory,
     setAddVideoCategoryValue,
-  } = useVideoCategories(basicVideoCategories);
+  } = useVideoCategories(uploadVideoCategories);
 
   const { addVideoMutation } = useVideos();
 
@@ -73,82 +62,89 @@ const VideoAddPage = () => {
 
   const handleReset = () => {
     reset();
-    setVideoCategories(basicVideoCategories);
+    setVideoCategories(uploadVideoCategories);
     setIsAddVideoCategory(false);
     setAddVideoCategoryValue('');
     setSelectedTags([]);
   };
 
   return (
-    <main className="flex flex-col gap-4">
-      <Controller
-        name="video_url"
-        control={control}
-        render={({ field }) => (
-          <VideoUploadBox videoURL={field.value} setVideoURL={field.onChange} />
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
+      <section>
+        <Controller
+          name="video_url"
+          control={control}
+          render={({ field }) => (
+            <VideoUploadBox
+              videoURL={field.value}
+              setVideoURL={field.onChange}
+            />
+          )}
+        />
+        {errors.video_url && (
+          <p className="text-red-500">{errors.video_url.message}</p>
         )}
-      />
-      {errors.video_url && (
-        <p style={{ color: 'red' }}>{errors.video_url.message}</p>
-      )}
+      </section>
 
-      <Controller
-        name="title"
-        control={control}
-        render={({ field }) => (
-          <LabelInput
-            title="영상 제목"
-            placeholder="영상 제목을 입력해주세요."
-            value={field.value}
-            onChange={field.onChange}
-          />
-        )}
-      />
-      {errors.title && <p style={{ color: 'red' }}>{errors.title.message}</p>}
+      <section>
+        <Controller
+          name="title"
+          control={control}
+          render={({ field }) => (
+            <LabelInput
+              title="영상 제목"
+              placeholder="영상 제목을 입력해주세요."
+              value={field.value}
+              onChange={field.onChange}
+            />
+          )}
+        />
+        {errors.title && <p className="text-red-500">{errors.title.message}</p>}
+      </section>
 
-      <Controller
-        name="hash_tag"
-        control={control}
-        render={({ field }) => (
-          <MyPageVideoCategories
-            selectedTags={field.value || []}
-            isAddVideoCategory={isAddVideoCategory}
-            addVideoCategoryValue={addVideoCategoryValue}
-            videoCategories={videoCategories}
-            toggleTag={tag => {
-              toggleTag(tag); // 상태 업데이트
-              if (field.value?.includes(tag)) {
-                field.onChange(field.value.filter(t => t !== tag)); // 태그 제거
-              } else {
-                field.onChange([...(field.value || []), tag]); // 태그 추가
-              }
-            }}
-            addVideoCategories={addVideoCategories}
-            handleAddVideoCategoryValue={handleAddVideoCategoryValue}
-          />
+      <section>
+        <Controller
+          name="hash_tag"
+          control={control}
+          render={({ field }) => (
+            <MyPageVideoCategories
+              selectedTags={field.value || []}
+              isAddVideoCategory={isAddVideoCategory}
+              addVideoCategoryValue={addVideoCategoryValue}
+              videoCategories={videoCategories}
+              toggleTag={tag => {
+                toggleTag(tag); // 상태 업데이트
+                if (field.value?.includes(tag)) {
+                  field.onChange(field.value.filter(t => t !== tag)); // 태그 제거
+                } else {
+                  field.onChange([...(field.value || []), tag]); // 태그 추가
+                }
+              }}
+              addVideoCategories={addVideoCategories}
+              handleAddVideoCategoryValue={handleAddVideoCategoryValue}
+            />
+          )}
+        />
+        {errors.hash_tag && (
+          <p className="text-red-500">{errors.hash_tag.message}</p>
         )}
-      />
-      {errors.hash_tag && (
-        <p style={{ color: 'red' }}>{errors.hash_tag.message}</p>
-      )}
+      </section>
 
-      <Controller
-        name="thumbnail"
-        control={control}
-        render={({ field }) => (
-          <ThumbnailUpload
-            imgFile={field.value || ''}
-            onImageChange={field.onChange}
-          />
-        )}
-      />
+      <section>
+        <Controller
+          name="thumbnail"
+          control={control}
+          render={({ field }) => (
+            <ThumbnailUpload
+              imgFile={field.value || ''}
+              onImageChange={field.onChange}
+            />
+          )}
+        />
+      </section>
 
       <div className="flex w-full gap-small">
-        <Button
-          type="submit"
-          className="w-1/2"
-          onClick={handleSubmit(onSubmit)}
-        >
+        <Button type="submit" className="w-1/2">
           업로드
         </Button>
         <Button
@@ -160,7 +156,7 @@ const VideoAddPage = () => {
           초기화
         </Button>
       </div>
-    </main>
+    </form>
   );
 };
 

--- a/src/schema/videoUploadSchema.ts
+++ b/src/schema/videoUploadSchema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { getYoutubeVideoId } from '@/utils/getYoutubeVideoId';
+
+const videoSchema = z.object({
+  video_url: z
+    .string()
+    .nonempty('유튜브 URL을 입력해주세요.')
+    .refine(
+      url => !!getYoutubeVideoId(url),
+      '유효한 유튜브 URL을 입력해주세요.',
+    ),
+  title: z.string().nonempty('영상 제목을 입력해주세요.'),
+  hash_tag: z.array(z.string()).min(1, '최소 하나의 카테고리를 선택해주세요.'),
+  thumbnail: z.string().optional(),
+});
+type VideoFormValues = z.infer<typeof videoSchema>;
+
+export { videoSchema };
+export type { VideoFormValues };

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -28,5 +28,32 @@ type VideoStatsProps = Omit<
   },
   ''
 >;
+type VideoUploadCategoryProps = {
+  selectedTags: string[];
+  isAddVideoCategory: boolean;
+  addVideoCategoryValue: string;
+  videoCategories: string[];
+  toggleTag: (tag: string) => void;
+  addVideoCategories: () => void;
+  handleAddVideoCategoryValue: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+type UploadVideoProps = {
+  video_url: string;
+  user_id?: string;
+  nickname?: string;
+  thumbnail: string;
+  title: string;
+  like_heart?: number;
+  is_bookmarked?: boolean;
+  hash_tag: string[];
+  created_at?: string | Date;
+};
 
-export type { VideoProps, VideoCategoryProps, VideoListProps, VideoStatsProps };
+export type {
+  VideoProps,
+  VideoCategoryProps,
+  VideoListProps,
+  VideoStatsProps,
+  VideoUploadCategoryProps,
+  UploadVideoProps,
+};


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #88 

## ✅ Task Details

- 동영상 업로드 페이지 기능 구현
-  supabse연동

## 📂 References

 ![image](https://github.com/user-attachments/assets/f3a8dfad-e8b9-4766-9c48-451e92e46d83)

1차수정
![image](https://github.com/user-attachments/assets/d9d99ee1-9742-4e15-9311-eecff9dcfc94)


## 💞 Review Requirements

- zod와 hook-form을 사용하면서 하위 컴포넌트 수정을 줄이려하다보니 가독성이 좀 떨어집니다... 우선 기능 구현이 먼저라고 생각되어 PR올립니다.(시간 되는 대로 추후 or 리펙토링 기간에 수정해보겠습니다.)
- 영상 업로드 완료시 toast로 업로드 완료 메시지를 내보내면서 home으로 리다이렉트 됩니다.
- 직접 이미지 파일 추가하는 경우의 로직이 수정이 필요할것으로 생각됩니다...(시간이 부족하다 느껴 후순위로 미뤄보겠습니다.. 현재 이미지 추가를 하지 않으면 유튜브 영상의 썸네일을 사용합니다.)
