### PR TITLE
feat: 작성자 팔로우 관련해서 supabase와 연동 (#111)

### DIFF
--- a/src/api/user-follow.ts
+++ b/src/api/user-follow.ts
@@ -1,0 +1,102 @@
+import { supabase } from './supabase';
+
+export async function toggleFollowButton(
+  followerId: string,
+  followingId: string,
+) {
+  const { data: existingFollow } = await supabase
+    .from('user_follow')
+    .select('*')
+    .eq('follower_id', followerId)
+    .eq('following_id', followingId)
+    .maybeSingle();
+
+  // 현재 사용자의 팔로워 수 조회
+  const { data: userData } = await supabase
+    .from('users')
+    .select('follower, following')
+    .eq('user_id', followingId)
+    .single();
+
+  const currentFollowerCount = userData?.follower || 0;
+
+  // 현재 사용자의 팔로잉 수 조회
+  const { data: followerData } = await supabase
+    .from('users')
+    .select('following')
+    .eq('user_id', followerId)
+    .single();
+
+  const currentFollowingCount = followerData?.following || 0;
+
+  if (existingFollow) {
+    const { error: deleteError } = await supabase
+      .from('user_follow')
+      .delete()
+      .eq('follower_id', followerId)
+      .eq('following_id', followingId);
+
+    if (deleteError) throw deleteError;
+
+    const { error: updateFollowerError } = await supabase
+      .from('users')
+      .update({ follower: currentFollowerCount - 1 })
+      .eq('user_id', followingId);
+
+    if (updateFollowerError) throw updateFollowerError;
+
+    const { error: updateFollowingError } = await supabase
+      .from('users')
+      .update({ following: currentFollowingCount - 1 })
+      .eq('user_id', followerId);
+
+    if (updateFollowingError) throw updateFollowingError;
+
+    return false;
+  } else {
+    const { error: insertError } = await supabase.from('user_follow').insert([
+      {
+        id: crypto.randomUUID(),
+        follower_id: followerId,
+        following_id: followingId,
+      },
+    ]);
+
+    if (insertError) throw insertError;
+
+    const { error: updateFollowerError } = await supabase
+      .from('users')
+      .update({ follower: currentFollowerCount + 1 })
+      .eq('user_id', followingId);
+
+    if (updateFollowerError) throw updateFollowerError;
+
+    const { error: updateFollowingError } = await supabase
+      .from('users')
+      .update({ following: currentFollowingCount + 1 })
+      .eq('user_id', followerId);
+
+    if (updateFollowingError) throw updateFollowingError;
+
+    return true;
+  }
+}
+
+export async function fetchFollowStatus(
+  followerId: string,
+  followingId: string,
+) {
+  const { data, error } = await supabase
+    .from('user_follow')
+    .select('*')
+    .eq('follower_id', followerId)
+    .eq('following_id', followingId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('팔로우 정보를 가져오는 데 실패했어요: ', error);
+    return false;
+  }
+
+  return !!data;
+}

--- a/src/components/author/AuthorProfile.tsx
+++ b/src/components/author/AuthorProfile.tsx
@@ -4,6 +4,7 @@ import { UserProps } from '@/types/user';
 import { VideoProps } from '@/types/video';
 import { formatNumber } from '@/utils/formatNumber';
 import { useFollow } from '@/hooks/useFollow';
+import { useUsers } from '@/hooks/useUsers';
 
 type AuthorProfileProps = {
   author: UserProps;
@@ -16,9 +17,12 @@ type StatItem = {
 };
 
 const AuthorProfile = ({ author, authorVideos }: AuthorProfileProps) => {
+  const { currentUserQuery } = useUsers();
   const { isFollowLoading, isFollowing, toggleFollow } = useFollow(
     author.user_id,
   );
+
+  const isSameUser = currentUserQuery.data?.user_id === author.user_id;
 
   const stats: StatItem[] = [
     { label: '팔로워', value: author.follower },
@@ -30,14 +34,16 @@ const AuthorProfile = ({ author, authorVideos }: AuthorProfileProps) => {
     <section className="flex flex-col gap-3">
       <header className="flex items-center gap-4">
         <h1 className="text-xl font-bold">{author.nickname}</h1>
-        <Button
-          variant={isFollowing ? 'primary' : 'outline'}
-          size="small"
-          onClick={() => toggleFollow()}
-          disabled={isFollowLoading}
-        >
-          {isFollowing ? '팔로잉' : '팔로우'}
-        </Button>
+        {!isSameUser && (
+          <Button
+            variant={isFollowing ? 'primary' : 'outline'}
+            size="small"
+            onClick={() => toggleFollow()}
+            disabled={isFollowLoading}
+          >
+            {isFollowing ? '팔로잉' : '팔로우'}
+          </Button>
+        )}
       </header>
 
       <article className="flex items-center gap-6 px-2">

--- a/src/components/author/AuthorProfile.tsx
+++ b/src/components/author/AuthorProfile.tsx
@@ -3,6 +3,7 @@ import blankProfile from '@/assets/user/blank-user.webp';
 import { UserProps } from '@/types/user';
 import { VideoProps } from '@/types/video';
 import { formatNumber } from '@/utils/formatNumber';
+import { useFollow } from '@/hooks/useFollow';
 
 type AuthorProfileProps = {
   author: UserProps;
@@ -15,6 +16,10 @@ type StatItem = {
 };
 
 const AuthorProfile = ({ author, authorVideos }: AuthorProfileProps) => {
+  const { isFollowLoading, isFollowing, toggleFollow } = useFollow(
+    author.user_id,
+  );
+
   const stats: StatItem[] = [
     { label: '팔로워', value: author.follower },
     { label: '팔로잉', value: author.following },
@@ -25,8 +30,13 @@ const AuthorProfile = ({ author, authorVideos }: AuthorProfileProps) => {
     <section className="flex flex-col gap-3">
       <header className="flex items-center gap-4">
         <h1 className="text-xl font-bold">{author.nickname}</h1>
-        <Button variant="outline" size="small">
-          팔로우
+        <Button
+          variant={isFollowing ? 'primary' : 'outline'}
+          size="small"
+          onClick={() => toggleFollow()}
+          disabled={isFollowLoading}
+        >
+          {isFollowing ? '팔로잉' : '팔로우'}
         </Button>
       </header>
 

--- a/src/components/video/VideoItem.tsx
+++ b/src/components/video/VideoItem.tsx
@@ -20,10 +20,11 @@ const VideoItem = ({
   video_id,
   isVideoDetailPage = false,
 }: VideoProps) => {
-  const { userQuery } = useUsers(user_id);
+  const { userQuery, currentUserQuery } = useUsers(user_id);
   const { isFollowLoading, isFollowing, toggleFollow } = useFollow(user_id);
 
   const userData = userQuery.data;
+  const isSameUser = currentUserQuery.data?.user_id === user_id;
 
   const ThumbnailContent =
     isVideoDetailPage && video_url ? (
@@ -65,14 +66,16 @@ const VideoItem = ({
           {userData && <SimpleProfile {...userData} />}
 
           {isVideoDetailPage ? (
-            <Button
-              variant={isFollowing ? 'primary' : 'outline'}
-              size="small"
-              onClick={() => toggleFollow()}
-              disabled={isFollowLoading}
-            >
-              {isFollowing ? '팔로잉' : '팔로우'}
-            </Button>
+            !isSameUser && (
+              <Button
+                variant={isFollowing ? 'primary' : 'outline'}
+                size="small"
+                onClick={() => toggleFollow()}
+                disabled={isFollowLoading}
+              >
+                {isFollowing ? '팔로잉' : '팔로우'}
+              </Button>
+            )
           ) : (
             <VideoStats
               {...{ video_id, created_at, is_bookmarked, like_heart }}

--- a/src/components/video/VideoItem.tsx
+++ b/src/components/video/VideoItem.tsx
@@ -6,6 +6,7 @@ import SimpleProfile from '../common/simple-profile/SimpleProfile';
 import Button from '../common/button/Button';
 import { VideoProps } from '@/types/video';
 import { useUsers } from '@/hooks/useUsers';
+import { useFollow } from '@/hooks/useFollow';
 
 const VideoItem = ({
   thumbnail,
@@ -20,6 +21,8 @@ const VideoItem = ({
   isVideoDetailPage = false,
 }: VideoProps) => {
   const { userQuery } = useUsers(user_id);
+  const { isFollowLoading, isFollowing, toggleFollow } = useFollow(user_id);
+
   const userData = userQuery.data;
 
   const ThumbnailContent =
@@ -62,8 +65,13 @@ const VideoItem = ({
           {userData && <SimpleProfile {...userData} />}
 
           {isVideoDetailPage ? (
-            <Button variant="outline" size="small">
-              팔로우
+            <Button
+              variant={isFollowing ? 'primary' : 'outline'}
+              size="small"
+              onClick={() => toggleFollow()}
+              disabled={isFollowLoading}
+            >
+              {isFollowing ? '팔로잉' : '팔로우'}
             </Button>
           ) : (
             <VideoStats

--- a/src/hooks/useFollow.ts
+++ b/src/hooks/useFollow.ts
@@ -18,6 +18,9 @@ export const useFollow = (targetUserId: string) => {
 
   const toggleFollowMutation = useMutation({
     mutationFn: () => {
+      if (currentUserQuery.data?.user_id === targetUserId) {
+        throw new Error('SELF_FOLLOW_ERROR');
+      }
       return toggleFollowButton(currentUserQuery.data!.user_id, targetUserId);
     },
     onSuccess: isFollowing => {
@@ -36,8 +39,12 @@ export const useFollow = (targetUserId: string) => {
       toastSuccess(isFollowing ? '팔로우했어요!' : '팔로우를 취소했어요!');
     },
     onError: error => {
-      toastError('팔로우 처리에 실패했어요. 다시 시도해주세요!');
-      console.error('팔로우 처리 실패:', error);
+      if (error.message === 'SELF_FOLLOW_ERROR') {
+        toastError('자기 자신을 팔로우할 수 없어요!');
+      } else {
+        toastError('팔로우 처리에 실패했어요. 다시 시도해주세요!');
+        console.error('팔로우 처리 실패:', error);
+      }
     },
   });
 

--- a/src/hooks/useFollow.ts
+++ b/src/hooks/useFollow.ts
@@ -1,0 +1,49 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { toggleFollowButton, fetchFollowStatus } from '@/api/user-follow';
+import { useUsers } from '@/hooks/useUsers';
+import { toastSuccess, toastError } from '@/utils/toast';
+
+export const useFollow = (targetUserId: string) => {
+  const queryClient = useQueryClient();
+  const { currentUserQuery } = useUsers();
+
+  const followQuery = useQuery({
+    queryKey: ['follow', targetUserId, currentUserQuery.data?.user_id],
+    queryFn: () =>
+      fetchFollowStatus(currentUserQuery.data!.user_id, targetUserId),
+    enabled:
+      !!currentUserQuery.data && currentUserQuery.data.user_id !== targetUserId,
+  });
+
+  const toggleFollowMutation = useMutation({
+    mutationFn: () => {
+      return toggleFollowButton(currentUserQuery.data!.user_id, targetUserId);
+    },
+    onSuccess: isFollowing => {
+      // 팔로우 상태 갱신
+      queryClient.invalidateQueries({
+        queryKey: ['follow', targetUserId, currentUserQuery.data?.user_id],
+      });
+      // 유저 정보 갱신
+      queryClient.invalidateQueries({
+        queryKey: ['user', targetUserId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['user', currentUserQuery.data?.user_id],
+      });
+
+      toastSuccess(isFollowing ? '팔로우했어요!' : '팔로우를 취소했어요!');
+    },
+    onError: error => {
+      toastError('팔로우 처리에 실패했어요. 다시 시도해주세요!');
+      console.error('팔로우 처리 실패:', error);
+    },
+  });
+
+  return {
+    isFollowing: followQuery.data ?? false,
+    toggleFollow: toggleFollowMutation.mutateAsync,
+    isFollowLoading: followQuery.isLoading || toggleFollowMutation.isPending,
+  };
+};

--- a/src/hooks/useVideoLikes.ts
+++ b/src/hooks/useVideoLikes.ts
@@ -48,7 +48,7 @@ const useVideoLikes = (videoId: string) => {
 
   return {
     isLiked: likeQuery.data,
-    likesCount: likesCountQuery.data,
+    likesCount: likesCountQuery.data ?? 0,
     toggleLike: toggleLikeMutation.mutateAsync,
     isLikeLoading: likeQuery.isLoading || likesCountQuery.isLoading,
   };


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #111 

## ✅ Task Details

### 번외

- 영상 좋아요 카운트에 초기값으로 NaN으로 나와서 초기값을 0으로 설정했어요. 
- 작성자 상세 페이지에 전체 영상을 가져와 필터링하는 것이 아닌 작성자가 업로드한 비디오 쿼리로 변경했어요.
- 영상 좋아요 토글 버튼 api에서 `videos` 테이블에 있는 `like_heart`와도 연동했어요. 

### 관련

- 사용자끼리 팔로우하는 api를 추가했어요. 이 때 `users` 테이블에 있는 `following`, `follower` 칼럼에도 갱신되도록 연동했어요.
- 사용자끼리 팔로우하는 쿼리를 추가했어요.
- 팔로우 버튼을 사용하는 `AuthorProfile`과 `VideoItem` 컴포넌트에 적용했어요.
- 자기 자신을 팔로우할 경우 쿼리가 실행되지 않도록 하고 에러 토스트가 뜨도록 했어요.

## 📂 References

https://github.com/user-attachments/assets/b4b027b9-2e8f-4299-926d-3223be17c54d

## 💞 Review Requirements

- 리뷰 요구사항을 적어주세요!
