### PR TITLE
feat: 내 정보 수정 페이지 supabase 연동 및 로직 추가(#117)

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -69,3 +69,18 @@ export async function addUser(newUser: UserProps) {
   if (error) throw error;
   return data;
 }
+
+// 닉네임 중복 검사
+export const checkNickname = async (userId: string, nickname: string) => {
+  const { data, error } = await supabase
+    .from('users')
+    .select('*')
+    .eq('nickname', nickname)
+    .neq('user_id', userId); // 본인의 레코드는 제외
+
+  if (error) {
+    throw new Error('닉네임 확인 중 오류가 발생했습니다.');
+  }
+
+  return data.length === 0; // 닉네임이 없으면 true 반환
+};

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -10,8 +10,12 @@ import {
 } from '@/api/users';
 
 import { UserProps, UpdateData } from '@/types/user';
+import { toastError, toastSuccess } from '@/utils/toast';
+import { ROUTER_PATH } from '@/constants/constants';
+import { useNavigate } from 'react-router-dom';
 
 const useUsers = (userId?: string) => {
+  const navigate = useNavigate();
   // 모든 사용자 조회
   const usersQuery = useQuery({
     queryKey: ['users'],
@@ -50,6 +54,14 @@ const useUsers = (userId?: string) => {
       userId: string;
       updateData: UpdateData;
     }) => updateUser(userId, updateData),
+    onSuccess: () => {
+      toastSuccess('프로필을 수정했습니다.');
+      navigate(ROUTER_PATH.MY_PAGE);
+    },
+    onError: (error: Error) => {
+      console.error('수정 데이터 업로드 실패:', error);
+      toastError('프로필 수정 중 오류가 발생했습니다.');
+    },
   });
 
   return {

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -53,7 +53,13 @@ const useUsers = (userId?: string) => {
     }: {
       userId: string;
       updateData: UpdateData;
-    }) => updateUser(userId, updateData),
+    }) =>
+      updateUser(
+        userId,
+        updateData.nickname === ''
+          ? { ...updateData, nickname: currentUserQuery.data.nickname }
+          : updateData,
+      ),
     onSuccess: () => {
       toastSuccess('프로필을 수정했습니다.');
       navigate(ROUTER_PATH.MY_PAGE);

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -7,6 +7,7 @@ import {
   fetchUserById,
   updateUser,
   fetchCurrentUser,
+  checkNickname,
 } from '@/api/users';
 
 import { UserProps, UpdateData } from '@/types/user';
@@ -70,6 +71,12 @@ const useUsers = (userId?: string) => {
     },
   });
 
+  // 닉네임 중복 확인
+  const checkUserNicknameMutation = useMutation({
+    mutationFn: ({ userId, nickname }: { userId: string; nickname: string }) =>
+      checkNickname(userId, nickname),
+  });
+
   return {
     usersQuery,
     userQuery,
@@ -77,6 +84,7 @@ const useUsers = (userId?: string) => {
     addUserMutation,
     deleteUserMutation,
     updateUserMutation,
+    checkUserNicknameMutation,
   };
 };
 

--- a/src/hooks/useVideos.ts
+++ b/src/hooks/useVideos.ts
@@ -19,6 +19,7 @@ import {
   fetchUserUploadVideos,
   fetchAllVideos,
   updateVideo,
+  deleteVideo,
 } from '@/api/videos';
 import { UploadVideoProps, VideoUpdateDataProps } from '@/types/video';
 import { useUsers } from './useUsers';

--- a/src/pages/my-page/MyPageEdit.tsx
+++ b/src/pages/my-page/MyPageEdit.tsx
@@ -1,36 +1,95 @@
 import Button from '@/components/common/button/Button';
 import LabelInput from '@/components/common/label-input/LabelInput';
-import { mockUsers } from '@/mocks/mockUsers';
-import { useState } from 'react';
 import MyPageEditProfileImage from '@/components/my-page/MyPageEditProfileImage';
+import { useUserStore } from '@/store/useUserStore';
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ProfileFormValues, profileSchema } from '@/schema/profileSchema';
+import { useUsers } from '@/hooks/useUsers';
 
 const MyPageEdit = () => {
-  const userData = mockUsers[0];
-  const [imgFile, setImgFile] = useState('');
+  const userData = useUserStore(state => state.user);
+  const { updateUserMutation } = useUsers();
+  const {
+    control,
+    formState: { errors },
+    handleSubmit,
+    setValue,
+    clearErrors,
+    reset,
+  } = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      user_image: userData?.user_image,
+      nickname: userData?.nickname,
+      description: userData?.description,
+    },
+  });
 
-  const handleImageReset = () => {
-    setImgFile('');
+  const handleImageChange = (imageFile: string) => {
+    setValue('user_image', imageFile, { shouldValidate: true });
+  };
+
+  const handleReset = () => {
+    reset();
+  };
+  const onSubmit = (data: ProfileFormValues) => {
+    updateUserMutation.mutate({ userId: userData!.user_id, updateData: data });
   };
 
   return (
-    <figure>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <MyPageEditProfileImage
-        userImage={userData.user_image as string}
-        onImageChange={setImgFile}
-        imgFile={imgFile}
+        userImage={userData?.user_image as string}
+        onImageChange={handleImageChange}
+        imgFile={control._formValues.user_image}
       />
+      {errors.user_image && (
+        <p className="text-sm text-red-500">{errors.user_image.message}</p>
+      )}
+      <Controller
+        name="nickname"
+        control={control}
+        render={({ field }) => (
+          <LabelInput
+            title="닉네임"
+            placeholder="수정할 닉네임을 작성해 주세요"
+            description={control._formValues.nickname}
+            onChange={e => {
+              field.onChange(e);
+              if (e.target.value) {
+                clearErrors('nickname');
+              }
+            }}
+            value={field.value}
+          />
+        )}
+      />
+      {errors.nickname && (
+        <p className="text-sm text-red-500">{errors.nickname.message}</p>
+      )}
 
-      <LabelInput
-        title="닉네임"
-        placeholder="수정할 닉네임을 작성해 주세요"
-        description={userData.nickname}
+      <Controller
+        name="description"
+        control={control}
+        render={({ field }) => (
+          <LabelInput
+            title="소개"
+            placeholder="한 줄 평을 작성해 주세요"
+            description={control._formValues.description}
+            onChange={e => {
+              field.onChange(e);
+              if (e.target.value) {
+                clearErrors('description');
+              }
+            }}
+            value={field.value}
+          />
+        )}
       />
-
-      <LabelInput
-        title="소개"
-        placeholder="한 줄 평을 작성해 주세요"
-        description={userData.description}
-      />
+      {errors.description && (
+        <p className="text-sm text-red-500">{errors.description.message}</p>
+      )}
 
       <div className="my-3 flex w-full gap-small">
         <Button type="submit" className="w-1/2">
@@ -40,12 +99,12 @@ const MyPageEdit = () => {
           type="reset"
           variant="outline"
           className="w-1/2"
-          onClick={handleImageReset}
+          onClick={handleReset}
         >
           초기화
         </Button>
       </div>
-    </figure>
+    </form>
   );
 };
 

--- a/src/schema/profileSchema.ts
+++ b/src/schema/profileSchema.ts
@@ -18,16 +18,16 @@ const profileSchema = z.object({
         const isGoogleImage = value.startsWith(
           'https://lh3.googleusercontent.com/',
         );
-        const isValidUrl = /^https?:\/\/.+\.(jpg|jpeg|png)(\?.*)?$/.test(value);
+        const isKakaoUrl = /^https?:\/\/.+\.(jpg|jpeg|png)(\?.*)?$/.test(value);
         //URL들은 구글, 카카오 로그인으로 인해 생성된 URL이기 때문
-        return isBase64Image || isGoogleImage || isValidUrl;
+        return isBase64Image || isGoogleImage || isKakaoUrl;
       },
       {
         message:
           '유효하지 않은 이미지 형식입니다. jpg, jpeg, png 파일만 허용합니다.',
       },
     ),
-  nickname: z.string().nonempty('이름을 입력해주세요'),
+  nickname: z.string().optional(),
   description: z.string().nonempty('소개를 입력해주세요'),
 });
 type ProfileFormValues = z.infer<typeof profileSchema>;

--- a/src/schema/profileSchema.ts
+++ b/src/schema/profileSchema.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+const profileSchema = z.object({
+  user_image: z
+    .string()
+    .min(1, { message: '썸네일을 선택해주세요' })
+    .refine(
+      value => {
+        const validPrefixes = [
+          'data:image/jpg;base64,',
+          'data:image/jpeg;base64,',
+          'data:image/png;base64,',
+        ];
+
+        const isBase64Image = validPrefixes.some(prefix =>
+          value.startsWith(prefix),
+        );
+        const isGoogleImage = value.startsWith(
+          'https://lh3.googleusercontent.com/',
+        );
+        const isValidUrl = /^https?:\/\/.+\.(jpg|jpeg|png)(\?.*)?$/.test(value);
+        //URL들은 구글, 카카오 로그인으로 인해 생성된 URL이기 때문
+        return isBase64Image || isGoogleImage || isValidUrl;
+      },
+      {
+        message:
+          '유효하지 않은 이미지 형식입니다. jpg, jpeg, png 파일만 허용합니다.',
+      },
+    ),
+  nickname: z.string().nonempty('이름을 입력해주세요'),
+  description: z.string().nonempty('소개를 입력해주세요'),
+});
+type ProfileFormValues = z.infer<typeof profileSchema>;
+
+export { profileSchema };
+export type { ProfileFormValues };


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #117 

## ✅ Task Details

- 내 정보 수정 페이지 supabase 연동 및 로직 추가

## 📂 References

https://github.com/user-attachments/assets/c7000a39-63e9-421e-a076-2de03fe403b8


- ![image](https://github.com/user-attachments/assets/59196147-4a69-47f3-ad9b-f55106bf7bc4)

## 💞 Review Requirements

- 프로필 관련 스키마에 구글, 카카오 로그인으로 인해 저장되어있는 이미지 url과 관련한 로직이 추가되어 있지만 파일을 받는 형식으로 진행되니까 오류 문구에는 파일과 관련된 문구만 작성하였습니다
