### PR TITLE
refactor: input 컴포넌트에 디바운싱 로직 일부 수정 (#124)

### DIFF
--- a/src/components/common/label-input/LabelInput.tsx
+++ b/src/components/common/label-input/LabelInput.tsx
@@ -21,20 +21,13 @@ const LabelInput = (props: LabelInputProps) => {
     delay: 300,
   });
 
-  useEffect(() => {
-    if (value !== undefined) {
-      setInputValue(value);
-    }
-  }, [value]);
+  const isControlled = (props.value === '' || props.value) && props.onChange;
 
   useEffect(() => {
-    if (onChange) {
-      const simulatedEvent = {
-        target: { value: debouncedValue },
-      } as React.ChangeEvent<HTMLInputElement>;
-      onChange(simulatedEvent);
+    if (!isControlled) {
+      setInputValue(debouncedValue);
     }
-  }, [debouncedValue, onChange]);
+  }, [debouncedValue, isControlled]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
@@ -47,8 +40,8 @@ const LabelInput = (props: LabelInputProps) => {
         {...inputProps}
         className="mt-1 w-full rounded-medium border border-black p-2 px-4 focus:!border-primary focus:outline-none"
         placeholder={placeholder}
-        value={inputValue}
-        onChange={handleChange}
+        value={isControlled ? value : inputValue}
+        onChange={isControlled ? onChange : handleChange}
       />
     </div>
   );

--- a/src/components/common/label-input/LabelInput.tsx
+++ b/src/components/common/label-input/LabelInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, InputHTMLAttributes, useState } from 'react';
+import { ChangeEvent, InputHTMLAttributes, useState, useEffect } from 'react';
 import { useDebounce } from '@/hooks/useDebounce';
 
 type LabelInputProps = InputHTMLAttributes<HTMLInputElement> & {
@@ -13,17 +13,31 @@ type LabelInputProps = InputHTMLAttributes<HTMLInputElement> & {
 const LabelInput = (props: LabelInputProps) => {
   const { title, placeholder, description, value, onChange, ...inputProps } =
     props;
-  const [desc, setDesc] = useState(description);
+
+  const [inputValue, setInputValue] = useState(value || description || '');
 
   const debouncedValue = useDebounce({
-    value: desc,
-    delay: 1000,
+    value: inputValue,
+    delay: 300,
   });
 
-  console.log(debouncedValue); //삭제 예정
+  useEffect(() => {
+    if (value !== undefined) {
+      setInputValue(value);
+    }
+  }, [value]);
+
+  useEffect(() => {
+    if (onChange) {
+      const simulatedEvent = {
+        target: { value: debouncedValue },
+      } as React.ChangeEvent<HTMLInputElement>;
+      onChange(simulatedEvent);
+    }
+  }, [debouncedValue, onChange]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setDesc(e.target.value);
+    setInputValue(e.target.value);
   };
 
   return (
@@ -33,14 +47,8 @@ const LabelInput = (props: LabelInputProps) => {
         {...inputProps}
         className="mt-1 w-full rounded-medium border border-black p-2 px-4 focus:!border-primary focus:outline-none"
         placeholder={placeholder}
-        value={
-          (props.value === '' || props.value) && props.onChange ? value : desc
-        }
-        onChange={
-          (props.value === '' || props.value) && props.onChange
-            ? onChange
-            : handleChange
-        }
+        value={inputValue}
+        onChange={handleChange}
       />
     </div>
   );

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
 
-type debounceProps<T> = {
+type DebounceProps<T> = {
   value: T;
   delay: number;
 };
 
-export function useDebounce<T>({ value, delay }: debounceProps<T>): T {
+export function useDebounce<T>({ value, delay }: DebounceProps<T>): T {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
   useEffect(() => {
@@ -16,7 +16,7 @@ export function useDebounce<T>({ value, delay }: debounceProps<T>): T {
     return () => {
       clearTimeout(handler);
     };
-  }, [value, delay]); // warning 때문에 delay 추가
+  }, [value, delay]);
 
   return debouncedValue;
 }


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #124 

## ✅ Task Details

- `useDebounce` 훅에서 타입명을 파스칼 케이스로 변경했어요.
- `LabelInput` 컴포넌트에서 콘솔 로그를 삭제했어요.
- 기존 상태의 이름을 명확하게 변경했어요.
- `controlled` 모드일 때는 입력값과 이벤트가 직접 부모 컴포넌트의 것을 사용하기 때문에 디바운싱이 적용되지 않아요.
- `uncontrolled` 모드일 때는 내부 상태로 관리해 디바운싱이 적용돼요.
- 다시 수정한 것은 디바운싱된 값을 부모에게 전달하려고 시도해서 영상 추가할 때 제대로 임베드되지 않아서 다시 수정했습니다!

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💞 Review Requirements

디바운싱 시간 1초는 너무 길고 보통 300ms~500ms가 적당하다고 하여 300ms로 변경했어요.
