### PR TITLE
feat: 댓글 개수에서 댓글과 대댓글 개수를 합쳐서 표현 (#133)

### DIFF
--- a/src/components/comment/VideoComment.tsx
+++ b/src/components/comment/VideoComment.tsx
@@ -12,7 +12,7 @@ type VideoCommentProps = {
 };
 
 const VideoComment = ({ videoId }: VideoCommentProps) => {
-  const { comments, isLoading } = useComments(videoId);
+  const { comments, totalCount, isLoading } = useComments(videoId);
   const resetExpandedComments = useCommentStore(
     state => state.resetExapandedComments,
   );
@@ -26,12 +26,10 @@ const VideoComment = ({ videoId }: VideoCommentProps) => {
 
   return (
     <main className="mt-6">
-      <h3 className="text-base font-bold">
-        댓글 {formatNumber(comments.length)}개
-      </h3>
+      <h3 className="text-base font-bold">댓글 {formatNumber(totalCount)}개</h3>
       <hr className="my-1" aria-hidden="true" />
 
-      {comments.length > 0 ? (
+      {totalCount > 0 ? (
         <CommentList comments={comments} videoId={videoId} />
       ) : (
         <EmptyResult message="작성된 댓글이 없습니다." />

--- a/src/components/video/VideoStats.tsx
+++ b/src/components/video/VideoStats.tsx
@@ -12,7 +12,7 @@ import { useBookmark } from '@/hooks/useBookmarks';
 import { useVideoLikes } from '@/hooks/useVideoLikes';
 
 const VideoStats = ({ video_id, created_at }: VideoStatsProps) => {
-  const { comments } = useComments(video_id);
+  const { totalCount } = useComments(video_id);
   const { isBookmarked, toggleBookmark, isBookmarkLoading } =
     useBookmark(video_id);
   const { isLiked, likesCount, toggleLike, isLikeLoading } =
@@ -40,7 +40,7 @@ const VideoStats = ({ video_id, created_at }: VideoStatsProps) => {
 
       <div className="flex items-center">
         <VscComment size={16} className="mr-1" />
-        <span className="text-xs">{formatNumber(comments.length)}</span>
+        <span className="text-xs">{formatNumber(totalCount)}</span>
       </div>
 
       <button

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -30,6 +30,11 @@ type Reply = CommonProps & {
 
 type CombinedCommentProps = Comment | Reply;
 
+type CommentResponse = {
+  comments: Comment[];
+  totalCount: number;
+};
+
 type CommentActionsProps = {
   thumb_up: number;
   thumb_down: number;
@@ -70,4 +75,5 @@ export type {
   CommentItemProps,
   CommentSubmitFormProps,
   CommentStore,
+  CommentResponse,
 };


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #133 

## ✅ Task Details

- 댓글과 대댓글을 조회하는 api를 추가했고 이를 쿼리 훅에도 적용했어요.
- 기존에 사용하던 `comments.length`를 없애고 서버에서 불러오는 합쳐진 값을 사용해요.

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💞 Review Requirements

- 클라이언트단에서 더 쉽고 간편하게 구현할 수 있었지만, 각 테이블에서 개수를 세고 합쳐지면 조금 로딩이 있을 수 있다고 생각하여 서버단에서 계산된 값을 불러오도록 했습니다!
