### PR TITLE
fix: 내 정보 페이지와 영상 수정 페이지에서 발생한 오류 수정 (#141)

### DIFF
--- a/src/components/my-page/MyPageUploadVideoList.tsx
+++ b/src/components/my-page/MyPageUploadVideoList.tsx
@@ -1,6 +1,7 @@
 import { VideoProps } from '@/types/video';
 import MyPageVideoItem from './MyPageVideoItem';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import EmptyResult from '../empty/EmptyResult';
 
 type UploadVideoListProps = {
   videos: VideoProps[];
@@ -8,15 +9,21 @@ type UploadVideoListProps = {
 
 const MyPageUploadVideoList = ({ videos }: UploadVideoListProps) => {
   return (
-    <Swiper slidesPerView={2.5} spaceBetween={16} className="z-0">
-      {videos.map((video: VideoProps) => (
-        <SwiperSlide key={video.video_id}>
-          <div className="flex flex-col">
-            <MyPageVideoItem {...video} myUploadVideos />
-          </div>
-        </SwiperSlide>
-      ))}
-    </Swiper>
+    <>
+      {videos.length === 0 ? (
+        <EmptyResult message="업로드한 영상이 없어요!" />
+      ) : (
+        <Swiper slidesPerView={2.5} spaceBetween={16} className="z-0">
+          {videos.map((video: VideoProps) => (
+            <SwiperSlide key={video.video_id}>
+              <div className="flex flex-col">
+                <MyPageVideoItem {...video} myUploadVideos />
+              </div>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      )}
+    </>
   );
 };
 

--- a/src/components/my-page/WatchedVideoList.tsx
+++ b/src/components/my-page/WatchedVideoList.tsx
@@ -3,6 +3,7 @@ import MyPageVideoItem from './MyPageVideoItem';
 import { getTimeAgo } from '@/utils/getTimeAgo';
 import { BsClockHistory } from 'react-icons/bs';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import EmptyResult from '../empty/EmptyResult';
 
 type MyPageVideoProps = {
   videos: VideoProps[];
@@ -10,19 +11,27 @@ type MyPageVideoProps = {
 
 const WatchedVideoList = ({ videos }: MyPageVideoProps) => {
   return (
-    <Swiper className="z-0" slidesPerView={2.5} spaceBetween={16}>
-      {videos.map((video: VideoProps) => (
-        <SwiperSlide key={video.video_id}>
-          <div className="flex flex-col">
-            <MyPageVideoItem {...video} />
-            <time className="flex flex-row-reverse">
-              <span className="text-xs">{getTimeAgo(video.created_at)}</span>
-              <BsClockHistory size={16} className="mr-1" />
-            </time>
-          </div>
-        </SwiperSlide>
-      ))}
-    </Swiper>
+    <>
+      {videos.length === 0 ? (
+        <EmptyResult message="좋아요한 영상이 없어요!" />
+      ) : (
+        <Swiper className="z-0" slidesPerView={2.5} spaceBetween={16}>
+          {videos.map((video: VideoProps) => (
+            <SwiperSlide key={video.video_id}>
+              <div className="flex flex-col">
+                <MyPageVideoItem {...video} />
+                <time className="flex flex-row-reverse">
+                  <span className="text-xs">
+                    {getTimeAgo(video.created_at)}
+                  </span>
+                  <BsClockHistory size={16} className="mr-1" />
+                </time>
+              </div>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      )}
+    </>
   );
 };
 

--- a/src/pages/VideoEditPage.tsx
+++ b/src/pages/VideoEditPage.tsx
@@ -82,7 +82,7 @@ const VideoEditPage = () => {
     setVideoCategoryList(uploadVideoCategories);
     setIsAddVideoCategory(false);
     setAddVideoCategoryValue('');
-    setSelectedTags([videoData.hash_tag]);
+    setSelectedTags(videoData.hash_tag);
   };
   if (isLoading) {
     return <VideoEditSkeleton />;

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -32,6 +32,10 @@ const MyPage = () => {
   const { data: uploadVideos, isLoading: myUploadVideosLoding } =
     myUploadVideos;
 
+  const handleRefresh = () => {
+    window.location.reload();
+  };
+
   if (likeVideosLoding || myUploadVideosLoding) {
     return <MyPageSkeleton />;
   }
@@ -44,7 +48,10 @@ const MyPage = () => {
         <p className="text-lg font-bold">내가 좋아요한 동영상</p>
         <hr className="my-2" aria-hidden="true" />
         {!likeVideosData ? (
-          <EmptyResult message="영상 데이터를 불러오는 데 실패했어요. 새로고침 해주세요!" />
+          <div className="flex flex-col items-center [&>main]:my-2">
+            <EmptyResult message="영상 데이터를 불러오는 데 실패했어요." />
+            <Button onClick={handleRefresh}>새로고침</Button>
+          </div>
         ) : (
           <WatchedVideoList videos={likeVideosData} />
         )}
@@ -53,13 +60,18 @@ const MyPage = () => {
       <section>
         <div className="flex items-center justify-between">
           <p className="text-lg font-bold">내가 업로드한 동영상</p>
-          <Link to={MY_UPLOAD_VIDEO}>
-            <Button size="small">더보기</Button>
-          </Link>
+          {uploadVideos && (
+            <Link to={MY_UPLOAD_VIDEO}>
+              <Button size="small">더보기</Button>
+            </Link>
+          )}
         </div>
         <hr className="my-2" aria-hidden="true" />
         {!uploadVideos ? (
-          <EmptyResult message="영상 데이터를 불러오는 데 실패했어요. 새로고침 해주세요!" />
+          <div className="flex flex-col items-center [&>main]:my-2">
+            <EmptyResult message="영상 데이터를 불러오는 데 실패했어요." />
+            <Button onClick={handleRefresh}>새로고침</Button>
+          </div>
         ) : (
           <MyPageUploadVideoList videos={uploadVideos} />
         )}

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -44,7 +44,7 @@ const MyPage = () => {
         <p className="text-lg font-bold">내가 좋아요한 동영상</p>
         <hr className="my-2" aria-hidden="true" />
         {!likeVideosData ? (
-          <EmptyResult message="영상 데이터가 없거나 불러오는 데 실패했어요 새로고침 해주세요!" />
+          <EmptyResult message="영상 데이터를 불러오는 데 실패했어요. 새로고침 해주세요!" />
         ) : (
           <WatchedVideoList videos={likeVideosData} />
         )}
@@ -59,7 +59,7 @@ const MyPage = () => {
         </div>
         <hr className="my-2" aria-hidden="true" />
         {!uploadVideos ? (
-          <EmptyResult message="영상 데이터가 없거나 불러오는 데 실패했어요 새로고침 해주세요!" />
+          <EmptyResult message="영상 데이터를 불러오는 데 실패했어요. 새로고침 해주세요!" />
         ) : (
           <MyPageUploadVideoList videos={uploadVideos} />
         )}

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -43,10 +43,10 @@ const MyPage = () => {
       <section>
         <p className="text-lg font-bold">내가 좋아요한 동영상</p>
         <hr className="my-2" aria-hidden="true" />
-        {likeVideosData?.length === 0 ? (
-          <EmptyResult message="시청 영상이 없어요!" />
+        {!likeVideosData ? (
+          <EmptyResult message="좋아요한 영상이 없어요!" />
         ) : (
-          <WatchedVideoList videos={likeVideosData!} />
+          <WatchedVideoList videos={likeVideosData} />
         )}
       </section>
 
@@ -58,10 +58,10 @@ const MyPage = () => {
           </Link>
         </div>
         <hr className="my-2" aria-hidden="true" />
-        {uploadVideos?.length === 0 ? (
+        {!uploadVideos ? (
           <EmptyResult message="업로드한 영상이 없어요!" />
         ) : (
-          <MyPageUploadVideoList videos={uploadVideos!} />
+          <MyPageUploadVideoList videos={uploadVideos} />
         )}
       </section>
 

--- a/src/pages/my-page/MyPage.tsx
+++ b/src/pages/my-page/MyPage.tsx
@@ -44,7 +44,7 @@ const MyPage = () => {
         <p className="text-lg font-bold">내가 좋아요한 동영상</p>
         <hr className="my-2" aria-hidden="true" />
         {!likeVideosData ? (
-          <EmptyResult message="좋아요한 영상이 없어요!" />
+          <EmptyResult message="영상 데이터가 없거나 불러오는 데 실패했어요 새로고침 해주세요!" />
         ) : (
           <WatchedVideoList videos={likeVideosData} />
         )}
@@ -59,7 +59,7 @@ const MyPage = () => {
         </div>
         <hr className="my-2" aria-hidden="true" />
         {!uploadVideos ? (
-          <EmptyResult message="업로드한 영상이 없어요!" />
+          <EmptyResult message="영상 데이터가 없거나 불러오는 데 실패했어요 새로고침 해주세요!" />
         ) : (
           <MyPageUploadVideoList videos={uploadVideos} />
         )}


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #141 

## ✅ Task Details

- 내 정보 페이지와 영상 수정 페이지에서 발생한 오류 수정


## 📂 References

- ![image](https://github.com/user-attachments/assets/dbf503dd-3b77-46be-8c9f-71bacd5ebbb1)


문구 수정

![image](https://github.com/user-attachments/assets/5c2a291f-48e8-499c-8869-b0f580b1df87)

최종 수정

![image](https://github.com/user-attachments/assets/7beec744-efe0-4a81-97dd-8e3c62d9ebd9)


## 💞 Review Requirements

- 기존 영상 데이터들이 배열 또는 undefined로 지정되어 배열의 길이를 통해 랜더링 되던 것은 각 컴포넌트 내부로 옮기고 데이터의 유무로 판단하여 사진과 같이 랜더링 하도록 변경하였습니다. 문구 관련 아이디어 적극 수용합니다!

- 기존에 발생하던 새로고침 오류가 위 조치로 해결 된 것으로 보이나 혹시나 다시 발생한다면 제보 부탁드립니다!

- 영상 수정 시 초기화 버튼을 누르면 태그들이 배열로 감싸지도록 되어 있어 대괄호 제거했습니다.
