### PR TITLE
fix: 카테고리 수정시 기존 동영상 로드 (#149)

### DIFF
--- a/src/pages/bookmark/BookmarkCategoryAddPage.tsx
+++ b/src/pages/bookmark/BookmarkCategoryAddPage.tsx
@@ -62,15 +62,9 @@ const BookmarkCategoryAddPage = () => {
   }
 
   const filteredVideos: VideoProps[] = object
-    ? videosAllQuery.data
-        ?.filter((video: VideoProps) => {
-          return object.categoried_videos.includes(video.video_id);
-        })
-        ?.filter((video: VideoProps) => {
-          return bookmarkQuery.data?.some(
-            bookmark => bookmark.video_id === video.video_id,
-          );
-        }) || []
+    ? videosAllQuery.data?.filter((video: VideoProps) => {
+        return object.categoried_videos.includes(video.video_id);
+      }) || []
     : videosAllQuery.data?.filter((video: VideoProps) => {
         return bookmarkQuery.data?.some(
           bookmark => bookmark.video_id === video.video_id,


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 [#149]

## ✅ Task Details

- BookmarkAddPage에서 
```
  const filteredVideos: VideoProps[] = object
    ? videosAllQuery.data?.filter((video: VideoProps) => {
        return object.categoried_videos.includes(video.video_id);
      }) || []
    : videosAllQuery.data?.filter((video: VideoProps) => {
        return bookmarkQuery.data?.some(
          bookmark => bookmark.video_id === video.video_id,
        );
      }) || [];
```
로 수정했습니다. 

데이터가 없을 때의 조건이 겹쳐서 오류를 발생하고 있었습니다.

## 📂 References


https://github.com/user-attachments/assets/adb777a6-5c66-4fdf-b673-d8ebe19ca3b4




## 💞 Review Requirements

- 리뷰 요구사항을 적어주세요!
