### PR TITLE
fix: zustand 적용한 영상 수정페이지 새로고침 시 데이터를 불러올 수 없던 오류 수정 (#147)

### DIFF
--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -4,15 +4,18 @@ import Button from '../common/button/Button';
 import { supabase } from '@/api/supabase';
 import { toastSuccess, toastError } from '@/utils/toast';
 import { ROUTER_PATH } from '@/constants/constants';
+import { useUserStore } from '@/store/useUserStore';
 
 const LogoutButton = () => {
   const navigate = useNavigate();
+  const clearUser = useUserStore(state => state.clearUser);
 
   const handleLogout = async () => {
     try {
       const { error } = await supabase.auth.signOut();
       if (error) throw error;
       toastSuccess('로그아웃 되었어요!');
+      clearUser();
       navigate(ROUTER_PATH.LOGIN);
     } catch (error) {
       console.error('로그아웃 실패:', error);

--- a/src/components/skeleton/my-page/MyUploadVideoItem.tsx
+++ b/src/components/skeleton/my-page/MyUploadVideoItem.tsx
@@ -1,9 +1,3 @@
-import { FaRegTrashAlt } from 'react-icons/fa';
-import { IoHeartOutline } from 'react-icons/io5';
-import { VscComment } from 'react-icons/vsc';
-import editLogo from '@/assets/basil_edit-outline.svg';
-import blankProfile from '@/assets/user/blank-user.webp';
-
 const MyUploadVideoItemSkeleton = () => {
   return (
     <article className="mb-1 flex h-16 w-full animate-pulse">
@@ -16,40 +10,26 @@ const MyUploadVideoItemSkeleton = () => {
 
         <div className="flex h-7 w-full flex-row items-center justify-between">
           <div className="flex items-center gap-1">
-            <figure
-              className={
-                'flex justify-center overflow-auto rounded-full border border-none'
-              }
-            >
-              <img
-                src={blankProfile}
-                alt="빈 프로필"
-                className="h-6 w-6 object-cover"
-              />
+            <figure className="flex justify-center overflow-auto rounded-full border border-none">
+              <div className="h-6 w-6 bg-gray-200 object-cover" />
             </figure>
-            <div className="h-3 w-32 overflow-hidden whitespace-nowrap bg-gray-200"></div>
+            <div className="h-3 w-20 overflow-hidden whitespace-nowrap bg-gray-200"></div>
           </div>
           <div className="flex items-center gap-2">
             <div className="flex items-center">
-              <IoHeartOutline size={16} className="mr-1" />
-              <div className="h-3 w-3"></div>
+              <div className="mr-1 h-4 w-4 bg-gray-200" />
             </div>
 
             <div className="flex items-center">
-              <VscComment size={16} className="mr-1" />
-              <div className="h-3 w-3"></div>
+              <div className="mr-1 h-4 w-4 bg-gray-200" />
             </div>
           </div>
 
           <div className="mt-1 flex w-14 justify-between text-gray">
             <div className="flex flex-grow items-center">
-              <FaRegTrashAlt size={25} className="mr-1" />
+              <div className="mr-1 h-[25px] w-[25px] bg-gray-200" />
 
-              <img
-                src={editLogo}
-                alt="수정 로고"
-                className="h-[30px] w-[30px] self-start"
-              />
+              <div className="h-[25px] w-[25px] self-start bg-gray-200" />
             </div>
           </div>
         </div>

--- a/src/components/skeleton/my-page/MyUploadVideoItem.tsx
+++ b/src/components/skeleton/my-page/MyUploadVideoItem.tsx
@@ -1,0 +1,61 @@
+import { FaRegTrashAlt } from 'react-icons/fa';
+import { IoHeartOutline } from 'react-icons/io5';
+import { VscComment } from 'react-icons/vsc';
+import editLogo from '@/assets/basil_edit-outline.svg';
+import blankProfile from '@/assets/user/blank-user.webp';
+
+const MyUploadVideoItemSkeleton = () => {
+  return (
+    <article className="mb-1 flex h-16 w-full animate-pulse">
+      <figure className="relative flex h-full w-32 items-center">
+        <div className="aspect-video h-full max-w-32 rounded-small bg-gray-200 object-cover" />
+      </figure>
+
+      <div className="ml-3 flex w-full min-w-0 flex-col">
+        <div className="mb-1 h-6 w-full overflow-hidden whitespace-nowrap bg-gray-200"></div>
+
+        <div className="flex h-7 w-full flex-row items-center justify-between">
+          <div className="flex items-center gap-1">
+            <figure
+              className={
+                'flex justify-center overflow-auto rounded-full border border-none'
+              }
+            >
+              <img
+                src={blankProfile}
+                alt="빈 프로필"
+                className="h-6 w-6 object-cover"
+              />
+            </figure>
+            <div className="h-3 w-32 overflow-hidden whitespace-nowrap bg-gray-200"></div>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center">
+              <IoHeartOutline size={16} className="mr-1" />
+              <div className="h-3 w-3"></div>
+            </div>
+
+            <div className="flex items-center">
+              <VscComment size={16} className="mr-1" />
+              <div className="h-3 w-3"></div>
+            </div>
+          </div>
+
+          <div className="mt-1 flex w-14 justify-between text-gray">
+            <div className="flex flex-grow items-center">
+              <FaRegTrashAlt size={25} className="mr-1" />
+
+              <img
+                src={editLogo}
+                alt="수정 로고"
+                className="h-[30px] w-[30px] self-start"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default MyUploadVideoItemSkeleton;

--- a/src/components/skeleton/my-page/MyUploadVideoItem.tsx
+++ b/src/components/skeleton/my-page/MyUploadVideoItem.tsx
@@ -2,34 +2,34 @@ const MyUploadVideoItemSkeleton = () => {
   return (
     <article className="mb-1 flex h-16 w-full animate-pulse">
       <figure className="relative flex h-full w-32 items-center">
-        <div className="aspect-video h-full max-w-32 rounded-small bg-gray-200 object-cover" />
+        <div className="aspect-video h-full max-w-32 rounded-md bg-gray-200 object-cover" />
       </figure>
 
       <div className="ml-3 flex w-full min-w-0 flex-col">
-        <div className="mb-1 h-6 w-full overflow-hidden whitespace-nowrap bg-gray-200"></div>
+        <div className="mb-1 h-6 w-full overflow-hidden whitespace-nowrap rounded-md bg-gray-200"></div>
 
         <div className="flex h-7 w-full flex-row items-center justify-between">
           <div className="flex items-center gap-1">
             <figure className="flex justify-center overflow-auto rounded-full border border-none">
               <div className="h-6 w-6 bg-gray-200 object-cover" />
             </figure>
-            <div className="h-3 w-20 overflow-hidden whitespace-nowrap bg-gray-200"></div>
+            <div className="h-3 w-20 overflow-hidden whitespace-nowrap rounded-md bg-gray-200"></div>
           </div>
           <div className="flex items-center gap-2">
             <div className="flex items-center">
-              <div className="mr-1 h-4 w-4 bg-gray-200" />
+              <div className="mr-1 h-4 w-4 rounded-md bg-gray-200" />
             </div>
 
             <div className="flex items-center">
-              <div className="mr-1 h-4 w-4 bg-gray-200" />
+              <div className="mr-1 h-4 w-4 rounded-md bg-gray-200" />
             </div>
           </div>
 
           <div className="mt-1 flex w-14 justify-between text-gray">
             <div className="flex flex-grow items-center">
-              <div className="mr-1 h-[25px] w-[25px] bg-gray-200" />
+              <div className="mr-1 h-[25px] w-[25px] rounded-md bg-gray-200" />
 
-              <div className="h-[25px] w-[25px] self-start bg-gray-200" />
+              <div className="h-[25px] w-[25px] self-start rounded-md bg-gray-200" />
             </div>
           </div>
         </div>

--- a/src/components/skeleton/my-page/MyUploadVideoListSkeleton.tsx
+++ b/src/components/skeleton/my-page/MyUploadVideoListSkeleton.tsx
@@ -1,6 +1,6 @@
-import MyUploadVideoItemSkeleton from './MyUploadVideoItem';
+import MyUploadVideoPageItemSkeleton from './MyUploadVideoItem';
 
-const MyUploadVideoListSkeleton = () => {
+const MyUploadVideoPageListSkeleton = () => {
   const emptyArray = Array.from({ length: 6 }, (_, index) => index + 1);
 
   return (
@@ -8,11 +8,11 @@ const MyUploadVideoListSkeleton = () => {
       <p className="mb-4 text-lg font-bold">내가 업로드한 동영상</p>
       <div className="flex flex-col gap-4">
         {emptyArray.map(item => (
-          <MyUploadVideoItemSkeleton key={item} />
+          <MyUploadVideoPageItemSkeleton key={item} />
         ))}
       </div>
     </>
   );
 };
 
-export default MyUploadVideoListSkeleton;
+export default MyUploadVideoPageListSkeleton;

--- a/src/components/skeleton/my-page/MyUploadVideoListSkeleton.tsx
+++ b/src/components/skeleton/my-page/MyUploadVideoListSkeleton.tsx
@@ -1,0 +1,18 @@
+import MyUploadVideoItemSkeleton from './MyUploadVideoItem';
+
+const MyUploadVideoListSkeleton = () => {
+  const emptyArray = Array.from({ length: 6 }, (_, index) => index + 1);
+
+  return (
+    <>
+      <p className="mb-4 text-lg font-bold">내가 업로드한 동영상</p>
+      <div className="flex flex-col gap-4">
+        {emptyArray.map(item => (
+          <MyUploadVideoItemSkeleton key={item} />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default MyUploadVideoListSkeleton;

--- a/src/pages/my-page/MyUploadVideoPage.tsx
+++ b/src/pages/my-page/MyUploadVideoPage.tsx
@@ -1,6 +1,6 @@
 import EmptyResult from '@/components/empty/EmptyResult';
 import MyUploadVideoList from '@/components/my-page/MyUploadVideoList';
-import MyUploadVideoListSkeleton from '@/components/skeleton/my-page/MyUploadVideoListSkeleton';
+import MyUploadVideoPageListSkeleton from '@/components/skeleton/my-page/MyUploadVideoListSkeleton';
 import { useVideos } from '@/hooks/useVideos';
 import { useUserStore } from '@/store/useUserStore';
 
@@ -12,7 +12,7 @@ const MyUploadVideoPage = () => {
   const { data: uploadVideos, isLoading } = myUploadVideos;
 
   if (isLoading) {
-    return <MyUploadVideoListSkeleton />;
+    return <MyUploadVideoPageListSkeleton />;
   }
   return (
     <main>

--- a/src/pages/my-page/MyUploadVideoPage.tsx
+++ b/src/pages/my-page/MyUploadVideoPage.tsx
@@ -1,4 +1,6 @@
+import EmptyResult from '@/components/empty/EmptyResult';
 import MyUploadVideoList from '@/components/my-page/MyUploadVideoList';
+import MyUploadVideoListSkeleton from '@/components/skeleton/my-page/MyUploadVideoListSkeleton';
 import { useVideos } from '@/hooks/useVideos';
 import { useUserStore } from '@/store/useUserStore';
 
@@ -7,13 +9,19 @@ const MyUploadVideoPage = () => {
   const { userUploadedVideosQuery: myUploadVideos } = useVideos({
     userId: currentUserData.user_id,
   });
-  const { data: uploadVideos } = myUploadVideos;
+  const { data: uploadVideos, isLoading } = myUploadVideos;
 
+  if (isLoading) {
+    return <MyUploadVideoListSkeleton />;
+  }
   return (
     <main>
       <p className="mb-4 text-lg font-bold">내가 업로드한 동영상</p>
-
-      <MyUploadVideoList videos={uploadVideos!} />
+      {uploadVideos?.length === 0 ? (
+        <EmptyResult message="업로드한 영상이 없어요!" />
+      ) : (
+        <MyUploadVideoList videos={uploadVideos!} />
+      )}
     </main>
   );
 };

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,12 +1,20 @@
 import { UserProps, UserStore } from '@/types/user';
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
-const useUserStore = create<UserStore>(set => ({
-  user: null,
-  setUser: (userData: UserProps) => {
-    set({ user: userData });
-  },
-  clearUser: () => set({ user: null }),
-}));
+const useUserStore = create(
+  persist<UserStore>(
+    set => ({
+      user: null,
+      setUser: (userData: UserProps) => {
+        set({ user: userData });
+      },
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: 'userStorage',
+    },
+  ),
+);
 
 export { useUserStore };


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 #147 

## ✅ Task Details

- persist를 활용하여 새로고침하더라도 userData가 초기화되지 않도록 수정
- 이에 따라 로그아웃 버튼에 userClear함수 추가
- 새로고침 시 영상 데이터 불러오는 과정에서 map메소드관련 오류 발생하여 skeleton 적용을 통해 데이터를 활용할 수 있도록 변경

## 📂 References

- ![image](https://github.com/user-attachments/assets/aec7d0c8-eb45-47cd-a7de-0f3c8adf2bbf)


수정
![image](https://github.com/user-attachments/assets/7ad4a1f6-a90e-4c06-8bde-a216bad3a50c)

## 💞 Review Requirements

- 리뷰 요구사항을 적어주세요!
