### PR TITLE
refactor: 북마크페이지에서 전체 카테고리 제거 (#156)

### DIFF
--- a/src/mocks/bookmarkCategories.ts
+++ b/src/mocks/bookmarkCategories.ts
@@ -1,3 +1,3 @@
-const bookmarkCategories = ['전체', '북마크만 보기', '카테고리'];
+const bookmarkCategories = ['북마크', '카테고리'];
 
 export { bookmarkCategories };

--- a/src/pages/bookmark/BookmarkPage.tsx
+++ b/src/pages/bookmark/BookmarkPage.tsx
@@ -32,7 +32,9 @@ const BookmarkPage = () => {
       />
       <BookmarkHeader
         title={
-          selectedCategory === '북마크' ? '나의 북마크 목록' : '북마크 카테고리'
+          selectedCategory === '북마크'
+            ? '나의 북마크 목록'
+            : '나의 북마크 카테고리'
         }
       />
 

--- a/src/pages/bookmark/BookmarkPage.tsx
+++ b/src/pages/bookmark/BookmarkPage.tsx
@@ -9,7 +9,7 @@ import { useUsers } from '@/hooks/useUsers';
 import { useBookmarkCheck } from '@/hooks/useBookmarks';
 
 const BookmarkPage = () => {
-  const [selectedCategory, setSelectedCategory] = useState('전체');
+  const [selectedCategory, setSelectedCategory] = useState('북마크');
   const { videosAllQuery } = useVideos();
   const { currentUserQuery } = useUsers();
 
@@ -17,7 +17,7 @@ const BookmarkPage = () => {
 
   const filteredVideos: VideoProps[] =
     videosAllQuery.data?.filter((video: VideoProps) => {
-      if (selectedCategory === '전체' || selectedCategory === '북마크만 보기') {
+      if (selectedCategory === '북마크') {
         return bookmarkQuery.data?.some(
           bookmark => bookmark.video_id === video.video_id,
         );
@@ -32,33 +32,19 @@ const BookmarkPage = () => {
       />
       <BookmarkHeader
         title={
-          selectedCategory === '전체' || selectedCategory === '북마크만 보기'
-            ? '나의 북마크 목록'
-            : '북마크 카테고리'
+          selectedCategory === '북마크' ? '나의 북마크 목록' : '북마크 카테고리'
         }
       />
-      {selectedCategory === '전체' && (
-        <>
-          <div className="flex max-h-[31vh] w-full flex-col gap-5 overflow-y-auto">
-            <BookmarkList videos={filteredVideos} />
-          </div>
-          <hr className="border-gray my-2 border" />
-          <h2 className="text-large font-bold text-black">북마크 카테고리</h2>
-          <div className="flex w-full flex-col gap-1 overflow-y-auto">
-            <BookmarkCategoryList />
-          </div>
-        </>
+
+      {selectedCategory === '북마크' && (
+        <div className="flex w-full flex-col gap-5 overflow-y-auto">
+          <BookmarkList videos={filteredVideos} />
+        </div>
       )}
 
       {selectedCategory === '카테고리' && (
         <div className="flex w-full flex-col gap-1 overflow-y-auto">
           <BookmarkCategoryList />
-        </div>
-      )}
-
-      {selectedCategory === '북마크만 보기' && (
-        <div className="flex w-full flex-col gap-5 overflow-y-auto">
-          <BookmarkList videos={filteredVideos} />
         </div>
       )}
     </main>


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 [#156]

## ✅ Task Details

1. 전체 카테고리 제거
2. 북마크 아이템, 북마크 카테고리로 분류

## 📂 References

![image](https://github.com/user-attachments/assets/3985101c-ebe3-448d-a414-faa406e92356)
![image](https://github.com/user-attachments/assets/33eadf44-38b3-4eb3-b9d6-a475e288f43a)


## 💞 Review Requirements
- 처음 페이지가 로드되면, 북마크 아이템들이 보입니다.
- 플레이리스트에서 팔로우한 다른 사람의 플레이리스트도 볼 수 있으므로 "나의" 북마크 카테고리로 수정했습니다
