### PR TITLE
refactor: 플레이리스트 페이지 팔로우한 사람 플리도 공유 (#159)

### DIFF
--- a/src/api/categories.ts
+++ b/src/api/categories.ts
@@ -32,6 +32,17 @@ export async function fetchCategories(userId: string) {
   return data || [];
 }
 
+// 특정 북마크 id 카테고리 조회
+export async function fetchIdCategories(categoried_id: string) {
+  const { data, error } = await supabase
+    .from('categories')
+    .select('*')
+    .eq('category_id', categoried_id);
+
+  if (error) throw error;
+  return data || [];
+}
+
 // 카테고리 저장 함수
 export async function saveCategories(props: SaveCategoriesProps) {
   const { checkedVideos, title, imgFile, userId } = props;

--- a/src/api/categories.ts
+++ b/src/api/categories.ts
@@ -10,6 +10,16 @@ type SaveCategoriesProps = {
   category_id?: string;
 };
 
+// 모든 사용자 북마크 카테고리 조회
+export async function fetchAllCategories() {
+  const { data, error } = await supabase
+    .from('categories')
+    .select('*')
+    .order('updated_at', { ascending: false });
+
+  if (error) throw error;
+  return data || [];
+}
 // 특정 사용자 북마크 카테고리 조회
 export async function fetchCategories(userId: string) {
   const { data, error } = await supabase

--- a/src/api/user-follow.ts
+++ b/src/api/user-follow.ts
@@ -100,3 +100,14 @@ export async function fetchFollowStatus(
 
   return !!data;
 }
+
+export async function fetchFollowings(userId: string) {
+  const { data, error } = await supabase
+    .from('user_follow')
+    .select('following_id')
+    .eq('follower_id', userId);
+
+  if (error) throw error;
+
+  return data;
+}

--- a/src/components/bookmark/BookmarkCategoryItem.tsx
+++ b/src/components/bookmark/BookmarkCategoryItem.tsx
@@ -1,6 +1,6 @@
 import SimpleProfile from '@/components/common/simple-profile/SimpleProfile';
-import BookmarkCategorySkeleton from '@/components/skeleton/bookmark/BookmarkCategorySkeleton';
-import MusicSkeleton from '@/components/skeleton/music/MusicSkeleton';
+// import BookmarkCategorySkeleton from '@/components/skeleton/bookmark/BookmarkCategorySkeleton';
+// import MusicSkeleton from '@/components/skeleton/music/MusicSkeleton';
 import { useUsers } from '@/hooks/useUsers';
 import { PlayListProps } from '@/types/playList';
 import { cn } from '@/utils/cn';
@@ -10,40 +10,43 @@ import { Link } from 'react-router-dom';
 type BookmarkCategoryItemProps = {
   category: PlayListProps;
   selectedCategory?: string;
-  isLoading: boolean;
   isBookmark: boolean;
 };
 
 const BookmarkCategoryItem = ({
   category,
   selectedCategory,
-  isLoading,
-  isBookmark,
 }: BookmarkCategoryItemProps) => {
   const { userQuery } = useUsers(category.user_id);
   const userData = userQuery.data;
 
-  if (isLoading || userQuery.isLoading) {
-    return isBookmark ? <BookmarkCategorySkeleton /> : <MusicSkeleton />;
-  }
-
+  // if (userQuery.isLoading) {
+  //   return isBookmark ? <BookmarkCategorySkeleton /> : <MusicSkeleton />;
+  // }
   return (
-    <Link to={`/playlist/${category.category_id}`} key={category.category_id}>
-      <div className="mb-2">
-        <figure className="relative mb-2 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
-          <img
-            src={category.category_thumbnail}
-            alt={category.category_id}
-            className="h-full w-full object-cover"
-          />
-        </figure>
+    <>
+      <div className="">
+        <Link
+          to={`/playlist/${category.category_id}`}
+          key={`link-${category.category_id}`}
+        >
+          <div className="mb-2">
+            <figure className="relative mb-2 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
+              <img
+                src={category.category_thumbnail}
+                alt={category.category_id}
+                className="h-full w-full object-cover"
+              />
+            </figure>
+          </div>
+        </Link>
         <div
           className={cn(
             'flex w-full flex-row justify-between gap-1',
             selectedCategory === '전체' && 'flex-col',
           )}
         >
-          <div className="relative flex w-[65%] flex-row overflow-hidden whitespace-nowrap">
+          <div className="relative flex w-[100%] flex-row overflow-hidden whitespace-nowrap">
             <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
               {category.title}
             </h2>
@@ -51,13 +54,20 @@ const BookmarkCategoryItem = ({
               ({category.categoried_videos?.length || 0})
             </h2>
           </div>
-          <SimpleProfile {...userData} imageSize="large" textSize="small" />
-          <p className="flex items-center text-small">
-            최종 수정일 {getTimeAgo(category.updated_at)}
-          </p>
+          <div className="min-w-20">
+            <SimpleProfile {...userData} imageSize="large" textSize="small" />
+          </div>
+          <Link
+            to={`/playlist/${category.category_id}`}
+            key={`link-title-${category.category_id}`}
+          >
+            <p className="flex items-center overflow-hidden whitespace-nowrap text-small">
+              최종 수정일 {getTimeAgo(category.updated_at)}
+            </p>
+          </Link>
         </div>
       </div>
-    </Link>
+    </>
   );
 };
 

--- a/src/components/bookmark/BookmarkCategoryItem.tsx
+++ b/src/components/bookmark/BookmarkCategoryItem.tsx
@@ -1,0 +1,64 @@
+import SimpleProfile from '@/components/common/simple-profile/SimpleProfile';
+import BookmarkCategorySkeleton from '@/components/skeleton/bookmark/BookmarkCategorySkeleton';
+import MusicSkeleton from '@/components/skeleton/music/MusicSkeleton';
+import { useUsers } from '@/hooks/useUsers';
+import { PlayListProps } from '@/types/playList';
+import { cn } from '@/utils/cn';
+import { getTimeAgo } from '@/utils/getTimeAgo';
+import { Link } from 'react-router-dom';
+
+type BookmarkCategoryItemProps = {
+  category: PlayListProps;
+  selectedCategory?: string;
+  isLoading: boolean;
+  isBookmark: boolean;
+};
+
+const BookmarkCategoryItem = ({
+  category,
+  selectedCategory,
+  isLoading,
+  isBookmark,
+}: BookmarkCategoryItemProps) => {
+  const { userQuery } = useUsers(category.user_id);
+  const userData = userQuery.data;
+
+  if (isLoading || userQuery.isLoading) {
+    return isBookmark ? <BookmarkCategorySkeleton /> : <MusicSkeleton />;
+  }
+
+  return (
+    <Link to={`/playlist/${category.category_id}`} key={category.category_id}>
+      <div className="mb-2">
+        <figure className="relative mb-2 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
+          <img
+            src={category.category_thumbnail}
+            alt={category.category_id}
+            className="h-full w-full object-cover"
+          />
+        </figure>
+        <div
+          className={cn(
+            'flex w-full flex-row justify-between gap-1',
+            selectedCategory === '전체' && 'flex-col',
+          )}
+        >
+          <div className="relative flex w-[65%] flex-row overflow-hidden whitespace-nowrap">
+            <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
+              {category.title}
+            </h2>
+            <h2 className="font-bold">
+              ({category.categoried_videos?.length || 0})
+            </h2>
+          </div>
+          <SimpleProfile {...userData} imageSize="large" textSize="small" />
+          <p className="flex items-center text-small">
+            최종 수정일 {getTimeAgo(category.updated_at)}
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export { BookmarkCategoryItem };

--- a/src/components/bookmark/BookmarkCategoryItem.tsx
+++ b/src/components/bookmark/BookmarkCategoryItem.tsx
@@ -25,48 +25,98 @@ const BookmarkCategoryItem = ({
   // }
   return (
     <>
-      <div className="">
-        <Link
-          to={`/playlist/${category.category_id}`}
-          key={`link-${category.category_id}`}
-        >
-          <div className="mb-2">
-            <figure className="relative mb-2 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
-              <img
-                src={category.category_thumbnail}
-                alt={category.category_id}
-                className="h-full w-full object-cover"
-              />
-            </figure>
+      {selectedCategory === '전체' ? (
+        <div className="">
+          <Link
+            to={`/playlist/${category.category_id}`}
+            key={`link-${category.category_id}`}
+          >
+            <div className="mb-2">
+              <figure className="relative mb-2 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
+                <img
+                  src={category.category_thumbnail}
+                  alt={category.category_id}
+                  className="h-full w-full object-cover"
+                />
+              </figure>
+            </div>
+          </Link>
+          <div
+            className={cn(
+              'flex w-full flex-row justify-between gap-1',
+              selectedCategory === '전체' && 'flex-col',
+            )}
+          >
+            <div className="relative flex w-[100%] flex-row overflow-hidden whitespace-nowrap">
+              <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
+                {category.title}
+              </h2>
+              <h2 className="font-bold">
+                ({category.categoried_videos?.length || 0})
+              </h2>
+            </div>
+            <div className="min-w-20">
+              <SimpleProfile {...userData} imageSize="large" textSize="small" />
+            </div>
+            <Link
+              to={`/playlist/${category.category_id}`}
+              key={`link-title-${category.category_id}`}
+            >
+              <p className="flex items-center overflow-hidden whitespace-nowrap text-xsmall">
+                최종 수정일 {getTimeAgo(category.updated_at)}
+              </p>
+            </Link>
           </div>
-        </Link>
-        <div
-          className={cn(
-            'flex w-full flex-row justify-between gap-1',
-            selectedCategory === '전체' && 'flex-col',
-          )}
-        >
-          <div className="relative flex w-[100%] flex-row overflow-hidden whitespace-nowrap">
-            <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
-              {category.title}
-            </h2>
-            <h2 className="font-bold">
-              ({category.categoried_videos?.length || 0})
-            </h2>
+        </div>
+      ) : (
+        <div className="">
+          <Link
+            to={`/playlist/${category.category_id}`}
+            key={`link-${category.category_id}`}
+          >
+            <div className="mb-2">
+              <figure className="relative mb-2 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
+                <img
+                  src={category.category_thumbnail}
+                  alt={category.category_id}
+                  className="h-full w-full object-cover"
+                />
+              </figure>
+            </div>
+          </Link>
+          <div
+            className={cn(
+              'flex w-full flex-row justify-between gap-1',
+              selectedCategory === '전체' && 'flex-col',
+            )}
+          >
+            <div
+              className={cn(
+                'relative flex w-[100%] flex-row items-center overflow-hidden whitespace-nowrap',
+              )}
+            >
+              <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
+                {category.title}
+              </h2>
+              <h2 className="font-bold">
+                ({category.categoried_videos?.length || 0})
+              </h2>
+              <div className="flex-grow" />
+              <Link
+                to={`/playlist/${category.category_id}`}
+                key={`link-title-${category.category_id}`}
+              >
+                <p className="flex items-center justify-end overflow-hidden whitespace-nowrap text-xsmall">
+                  최종 수정일 {getTimeAgo(category.updated_at)}
+                </p>
+              </Link>
+            </div>
           </div>
           <div className="min-w-20">
             <SimpleProfile {...userData} imageSize="large" textSize="small" />
           </div>
-          <Link
-            to={`/playlist/${category.category_id}`}
-            key={`link-title-${category.category_id}`}
-          >
-            <p className="flex items-center overflow-hidden whitespace-nowrap text-small">
-              최종 수정일 {getTimeAgo(category.updated_at)}
-            </p>
-          </Link>
         </div>
-      </div>
+      )}
     </>
   );
 };

--- a/src/components/bookmark/BookmarkCategoryItem.tsx
+++ b/src/components/bookmark/BookmarkCategoryItem.tsx
@@ -69,7 +69,7 @@ const BookmarkCategoryItem = ({
           </div>
         </div>
       ) : (
-        <div className="">
+        <div className="mb-4">
           <Link
             to={`/playlist/${category.category_id}`}
             key={`link-${category.category_id}`}
@@ -86,13 +86,13 @@ const BookmarkCategoryItem = ({
           </Link>
           <div
             className={cn(
-              'flex w-full flex-row justify-between gap-1',
+              'flex w-full flex-row items-center justify-between gap-1',
               selectedCategory === '전체' && 'flex-col',
             )}
           >
             <div
               className={cn(
-                'relative flex w-[100%] flex-row items-center overflow-hidden whitespace-nowrap',
+                'relative flex w-[100%] flex-row items-center gap-1 overflow-hidden whitespace-nowrap',
               )}
             >
               <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">

--- a/src/components/bookmark/BookmarkCategoryList.tsx
+++ b/src/components/bookmark/BookmarkCategoryList.tsx
@@ -1,13 +1,11 @@
 import { useCategories } from '@/hooks/useCategories';
-import { getTimeAgo } from '@/utils/getTimeAgo';
 import { Link, useLocation } from 'react-router-dom';
 import { useUsers } from '@/hooks/useUsers';
 import EmptyResult from '@/components/empty/EmptyResult';
-import { cn } from '@/utils/cn';
-import BookmarkCategorySkeleton from '@/components/skeleton/bookmark/BookmarkCategorySkeleton';
-import MusicSkeleton from '@/components/skeleton/music/MusicSkeleton';
 import Button from '@/components/common/button/Button';
 import { ROUTER_PATH } from '@/constants/constants';
+import { useFollow } from '@/hooks/useFollow';
+import { BookmarkCategoryItem } from '@/components/bookmark/BookmarkCategoryItem';
 
 const BookmarkCategoryList = ({
   selectedCategory,
@@ -15,86 +13,74 @@ const BookmarkCategoryList = ({
   selectedCategory?: string;
 }) => {
   const { currentUserQuery } = useUsers();
-
-  const { categoriesQuery } = useCategories(currentUserQuery.data.user_id);
+  const { categoriesQuery, allCategoriesQuery } = useCategories(
+    currentUserQuery.data?.user_id,
+  );
   const { BOOKMARK_CATEGORY_ADD } = ROUTER_PATH;
   const location = useLocation();
   const isBookmark = location.pathname.endsWith('/bookmark');
+  const { followingsIds, isFollowLoading } = useFollow(
+    currentUserQuery.data?.user_id,
+  );
 
-  if (categoriesQuery.isLoading) {
-    return isBookmark ? <BookmarkCategorySkeleton /> : <MusicSkeleton />;
-  }
+  const isLoading = categoriesQuery.isLoading || isFollowLoading;
 
   if (categoriesQuery.isError) {
     return <div>Error: {categoriesQuery.error?.message}</div>;
   }
 
-  const filteredCategories = categoriesQuery.data?.filter(category => {
-    return category.is_like === true;
-  });
+  const filteredCategories = [
+    ...(isBookmark
+      ? categoriesQuery.data?.filter(
+          category => category.user_id === currentUserQuery.data?.user_id,
+        ) || []
+      : [
+          ...(allCategoriesQuery.data?.filter(category =>
+            followingsIds.some(
+              followingId => followingId.following_id === category.user_id,
+            ),
+          ) || []),
+          ...(categoriesQuery.data?.filter(
+            category => category.user_id === currentUserQuery.data?.user_id,
+          ) || []),
+        ]),
+  ];
 
   const message = isBookmark
     ? '카테고리를 추가해볼까요?'
     : '플레이리스트를 추가해볼까요?';
 
-  return (
-    <>
-      <div
-        className={` ${filteredCategories?.length !== 0 && selectedCategory === '전체' && 'grid w-full grid-cols-2 gap-4'}`}
-      >
-        {filteredCategories?.length === 0 ? (
-          <>
-            <EmptyResult message={message} />
-            {isBookmark ? (
-              ''
-            ) : (
-              <div className="flex justify-center">
-                <Link to={BOOKMARK_CATEGORY_ADD}>
-                  <Button variant="secondary" className="items-center">
-                    플레이리스트 추가하기
-                  </Button>
-                </Link>
-              </div>
-            )}
-          </>
-        ) : (
-          filteredCategories?.map(category => (
-            <Link
-              to={`/playlist/${category.category_id}`}
-              key={category.category_id}
-            >
-              <div className="mb-2">
-                <figure className="relative mb-2 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
-                  <img
-                    src={category.category_thumbnail}
-                    alt={category.category_id}
-                    className="h-full w-full object-cover"
-                  />
-                </figure>
-                <div
-                  className={cn(
-                    'flex w-full flex-row justify-between gap-1',
-                    selectedCategory === '전체' && 'flex-col',
-                  )}
-                >
-                  <div className="relative flex w-[65%] flex-row overflow-hidden whitespace-nowrap">
-                    <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
-                      {category.title}
-                    </h2>
-                    <h2 className="font-bold">
-                      ({category.categoried_videos?.length || 0})
-                    </h2>
-                  </div>
-                  <p className="flex items-center text-small">
-                    최종 수정일 {getTimeAgo(category.updated_at)}
-                  </p>
-                </div>
-              </div>
+  if (filteredCategories?.length === 0) {
+    return (
+      <>
+        <EmptyResult message={message} />
+        {!isBookmark && (
+          <div className="flex justify-center">
+            <Link to={BOOKMARK_CATEGORY_ADD}>
+              <Button variant="secondary" className="items-center">
+                플레이리스트 추가하기
+              </Button>
             </Link>
-          ))
+          </div>
         )}
-      </div>
-    </>
+      </>
+    );
+  }
+
+  return (
+    <div
+      className={`${selectedCategory === '전체' && 'grid w-full grid-cols-2 gap-4'}`}
+    >
+      {filteredCategories.map(category => (
+        <BookmarkCategoryItem
+          key={category.category_id}
+          category={category}
+          selectedCategory={selectedCategory}
+          isLoading={isLoading}
+          isBookmark={isBookmark}
+        />
+      ))}
+    </div>
   );
 };
 

--- a/src/components/bookmark/BookmarkCategoryList.tsx
+++ b/src/components/bookmark/BookmarkCategoryList.tsx
@@ -19,15 +19,7 @@ const BookmarkCategoryList = ({
   const { BOOKMARK_CATEGORY_ADD } = ROUTER_PATH;
   const location = useLocation();
   const isBookmark = location.pathname.endsWith('/bookmark');
-  const { followingsIds, isFollowLoading } = useFollow(
-    currentUserQuery.data?.user_id,
-  );
-
-  const isLoading = categoriesQuery.isLoading || isFollowLoading;
-
-  if (categoriesQuery.isError) {
-    return <div>Error: {categoriesQuery.error?.message}</div>;
-  }
+  const { followingsIds } = useFollow(currentUserQuery.data?.user_id);
 
   const filteredCategories = [
     ...(isBookmark
@@ -76,7 +68,6 @@ const BookmarkCategoryList = ({
           key={category.category_id}
           category={category}
           selectedCategory={selectedCategory}
-          isLoading={isLoading}
           isBookmark={isBookmark}
         />
       ))}

--- a/src/components/playlist/PlayMusicList.tsx
+++ b/src/components/playlist/PlayMusicList.tsx
@@ -32,7 +32,12 @@ const PlayMusicList = ({ selectedCategory }: { selectedCategory?: string }) => {
                   selectedCategory === '전체' && 'flex-col',
                 )}
               >
-                <div className="relative flex w-[100%] flex-row overflow-hidden whitespace-nowrap">
+                <div
+                  className={cn(
+                    'relative flex flex-row overflow-hidden whitespace-nowrap',
+                    selectedCategory === '전체' ? 'w-[100%]' : `w-[60%]`,
+                  )}
+                >
                   <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
                     {music.title}
                   </h2>
@@ -40,9 +45,16 @@ const PlayMusicList = ({ selectedCategory }: { selectedCategory?: string }) => {
                     ({(music.categoried_videos || []).length})
                   </h2>
                 </div>
-                <p className="mr-1 flex min-w-[20%] items-center text-small">
-                  최종 수정일 {getTimeAgo(music.updated_at)}
-                </p>
+                <div
+                  className={cn(
+                    'flex',
+                    selectedCategory === '음악만 보기' && 'justify-end',
+                  )}
+                >
+                  <p className="mr-1 min-w-[31%] items-center text-small">
+                    최종 수정일 {getTimeAgo(music.updated_at)}
+                  </p>
+                </div>
               </div>
             </div>
           </Link>

--- a/src/components/playlist/PlayMusicList.tsx
+++ b/src/components/playlist/PlayMusicList.tsx
@@ -51,7 +51,7 @@ const PlayMusicList = ({ selectedCategory }: { selectedCategory?: string }) => {
                     selectedCategory === '음악만 보기' && 'justify-end',
                   )}
                 >
-                  <p className="mr-1 min-w-[31%] items-center text-small">
+                  <p className="mr-1 min-w-[31%] items-center text-xsmall">
                     최종 수정일 {getTimeAgo(music.updated_at)}
                   </p>
                 </div>

--- a/src/components/playlist/PlayMusicList.tsx
+++ b/src/components/playlist/PlayMusicList.tsx
@@ -18,8 +18,8 @@ const PlayMusicList = ({ selectedCategory }: { selectedCategory?: string }) => {
       >
         {musics?.map(music => (
           <Link to={`/playlist/${music.list_id}`} key={music.list_id}>
-            <div className="mb-2">
-              <figure className="relative mb-3 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
+            <div className="mb-4">
+              <figure className="relative mb-2 aspect-video h-[80%] w-full overflow-hidden rounded-lg">
                 <img
                   src={music.category_thumbnail}
                   alt={music.title}
@@ -28,14 +28,14 @@ const PlayMusicList = ({ selectedCategory }: { selectedCategory?: string }) => {
               </figure>
               <div
                 className={cn(
-                  'flex w-full flex-row justify-between gap-1',
+                  'flex w-full flex-row justify-between',
                   selectedCategory === '전체' && 'flex-col',
                 )}
               >
                 <div
                   className={cn(
                     'relative flex flex-row overflow-hidden whitespace-nowrap',
-                    selectedCategory === '전체' ? 'w-[100%]' : `w-[60%]`,
+                    selectedCategory === '전체' ? 'w-[100%]' : `w-[70%]`,
                   )}
                 >
                   <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
@@ -47,7 +47,7 @@ const PlayMusicList = ({ selectedCategory }: { selectedCategory?: string }) => {
                 </div>
                 <div
                   className={cn(
-                    'flex',
+                    'flex items-center',
                     selectedCategory === '음악만 보기' && 'justify-end',
                   )}
                 >

--- a/src/components/playlist/PlayMusicList.tsx
+++ b/src/components/playlist/PlayMusicList.tsx
@@ -32,7 +32,7 @@ const PlayMusicList = ({ selectedCategory }: { selectedCategory?: string }) => {
                   selectedCategory === '전체' && 'flex-col',
                 )}
               >
-                <div className="relative flex w-[65%] flex-row overflow-hidden whitespace-nowrap">
+                <div className="relative flex w-[100%] flex-row overflow-hidden whitespace-nowrap">
                   <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
                     {music.title}
                   </h2>
@@ -40,7 +40,7 @@ const PlayMusicList = ({ selectedCategory }: { selectedCategory?: string }) => {
                     ({(music.categoried_videos || []).length})
                   </h2>
                 </div>
-                <p className="mr-1 flex items-center text-small">
+                <p className="mr-1 flex min-w-[20%] items-center text-small">
                   최종 수정일 {getTimeAgo(music.updated_at)}
                 </p>
               </div>

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,5 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { fetchCategories, deleteCategories } from '@/api/categories';
+import {
+  fetchCategories,
+  deleteCategories,
+  fetchAllCategories,
+} from '@/api/categories';
 import { toastError, toastSuccess } from '@/utils/toast';
 
 const useCategories = (userId: string) => {
@@ -8,6 +12,17 @@ const useCategories = (userId: string) => {
   const categoriesQuery = useQuery({
     queryKey: ['categories', userId],
     queryFn: () => fetchCategories(userId),
+    select: data =>
+      data.map(category => ({
+        ...category,
+        updated_at: new Date(category.updated_at),
+      })),
+    enabled: !!userId,
+  });
+
+  const allCategoriesQuery = useQuery({
+    queryKey: ['allCategories'],
+    queryFn: () => fetchAllCategories(),
     select: data =>
       data.map(category => ({
         ...category,
@@ -29,6 +44,7 @@ const useCategories = (userId: string) => {
   });
 
   return {
+    allCategoriesQuery,
     categoriesQuery,
     deleteCategoriesQuery,
   };

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -3,6 +3,7 @@ import {
   fetchCategories,
   deleteCategories,
   fetchAllCategories,
+  fetchIdCategories,
 } from '@/api/categories';
 import { toastError, toastSuccess } from '@/utils/toast';
 
@@ -12,6 +13,17 @@ const useCategories = (userId: string) => {
   const categoriesQuery = useQuery({
     queryKey: ['categories', userId],
     queryFn: () => fetchCategories(userId),
+    select: data =>
+      data.map(category => ({
+        ...category,
+        updated_at: new Date(category.updated_at),
+      })),
+    enabled: !!userId,
+  });
+
+  const categoriesIdQuery = useQuery({
+    queryKey: ['categoriesId', userId],
+    queryFn: () => fetchIdCategories(userId as string),
     select: data =>
       data.map(category => ({
         ...category,
@@ -45,6 +57,7 @@ const useCategories = (userId: string) => {
 
   return {
     allCategoriesQuery,
+    categoriesIdQuery,
     categoriesQuery,
     deleteCategoriesQuery,
   };

--- a/src/hooks/useFollow.ts
+++ b/src/hooks/useFollow.ts
@@ -1,6 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { toggleFollowButton, fetchFollowStatus } from '@/api/user-follow';
+import {
+  toggleFollowButton,
+  fetchFollowStatus,
+  fetchFollowings,
+} from '@/api/user-follow';
 import { useUsers } from '@/hooks/useUsers';
 import { toastSuccess, toastError } from '@/utils/toast';
 
@@ -14,6 +18,12 @@ export const useFollow = (targetUserId: string) => {
       fetchFollowStatus(currentUserQuery.data!.user_id, targetUserId),
     enabled:
       !!currentUserQuery.data && currentUserQuery.data.user_id !== targetUserId,
+  });
+
+  const followingsQuery = useQuery({
+    queryKey: ['followings', currentUserQuery.data?.user_id],
+    queryFn: () => fetchFollowings(currentUserQuery.data.user_id),
+    enabled: !!currentUserQuery.data,
   });
 
   const toggleFollowMutation = useMutation({
@@ -49,6 +59,7 @@ export const useFollow = (targetUserId: string) => {
   });
 
   return {
+    followingsIds: followingsQuery.data ?? [],
     isFollowing: followQuery.data ?? false,
     toggleFollow: toggleFollowMutation.mutateAsync,
     isFollowLoading: followQuery.isLoading || toggleFollowMutation.isPending,

--- a/src/pages/playlist/PlayListDetailPage.tsx
+++ b/src/pages/playlist/PlayListDetailPage.tsx
@@ -6,12 +6,10 @@ import { useCategories } from '@/hooks/useCategories';
 import { useVideos } from '@/hooks/useVideos';
 import { PlayListProps } from '@/types/playList';
 import { useMusics } from '@/hooks/useMusics';
-import { useUsers } from '@/hooks/useUsers';
 
 const PlayListDetailPage = () => {
-  const { currentUserQuery } = useUsers();
-  const { categoriesQuery } = useCategories(currentUserQuery.data.user_id);
   const { playlistId } = useParams();
+  const { categoriesIdQuery } = useCategories(playlistId as string);
   const [videoUrl, setVideoUrl] = useState('');
   const { videosQuery } = useVideos();
   const musicsQuery = useMusics();
@@ -20,8 +18,8 @@ const PlayListDetailPage = () => {
     return <div>Error: {videosQuery.error?.message}</div>;
   }
 
-  if (categoriesQuery.isError) {
-    return <div>Error: {categoriesQuery.error?.message}</div>;
+  if (categoriesIdQuery.isError) {
+    return <div>Error: {categoriesIdQuery.error?.message}</div>;
   }
 
   if (musicsQuery.isError) {
@@ -30,7 +28,7 @@ const PlayListDetailPage = () => {
 
   // 카테고리 필터링
   const filteredPlayLists: PlayListProps[] = (
-    categoriesQuery.data || []
+    categoriesIdQuery.data || []
   ).filter(category => {
     return category.category_id === String(playlistId);
   });

--- a/src/pages/playlist/PlayListPage.tsx
+++ b/src/pages/playlist/PlayListPage.tsx
@@ -14,9 +14,7 @@ const PlayListPage = () => {
   const { categoriesQuery } = useCategories(currentUserQuery.data?.user_id);
   const { data: musics, isLoading: isMusicsLoading } = useMusics();
 
-  const isLoading = isMusicsLoading || categoriesQuery.isLoading;
-
-  if (isLoading) {
+  if (isMusicsLoading || categoriesQuery.isLoading) {
     return <MusicSkeleton />;
   }
 


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 [#159]

## ✅ Task Details

- 팔로우한 다른 사람의 플리를 확인할 수 있습니다.

## 📂 References

https://github.com/user-attachments/assets/0e988e27-3aee-4ae5-b2ad-41b8dede889e


## 💞 Review Requirements

-  BookmarkCategory의 user_id를 참조하기 위해 컴포넌트를 분리하여 접근했습니다
- 특정 북마크 id 카테고리 조회에 대한 hook을 추가했습니다
- 로그인한 사용자의 팔로우한 사라을 찾기위해 hook을 추가했습니다


현재 렌더링이 의도한대로 동작하지 않습니다.
skeleton -> EmptyResult -> filteredCategories 렌더링 
다음 이슈에서 이것을 해결할 예정입니다


## 리뷰 반영 수정

![image](https://github.com/user-attachments/assets/ac03f4cb-bb35-4529-b7be-bb18af2e68d8)
![image](https://github.com/user-attachments/assets/c739910a-cdb3-4273-bceb-c63b83b53723)

