### PR TITLE
style: BookmarkItem에서 figure와 img에 적용한 h-full 옵션 삭제 (#177)

### DIFF
--- a/src/components/bookmark/BookmarkItem.tsx
+++ b/src/components/bookmark/BookmarkItem.tsx
@@ -22,12 +22,12 @@ const BookmarkItem = ({
 
   return (
     <article className="mb-1 flex">
-      <figure className="relative flex h-full w-32 items-center">
+      <figure className="relative flex aspect-video w-32 items-center">
         <Link to={`/video/${video_id}`}>
           <img
             src={thumbnail}
             alt={title}
-            className="aspect-video h-full max-w-32 rounded-small object-cover"
+            className="aspect-video max-w-32 rounded-small object-cover"
           />
         </Link>
       </figure>


### PR DESCRIPTION
## 🚀 Related Issues

- 이슈 넘버 [#177]

## ✅ Task Details

- figure와 img에 적용한 h-full 옵션 삭제하여
모바일 환경에서 의도한대로 출력합니다

## 📂 References

- 스크린샷이나 레퍼런스를 넣어주세요!

## 💞 Review Requirements

- 리뷰 요구사항을 적어주세요!
